### PR TITLE
feat: add sidebarOpen configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Additional commands:
 
 ## Sidebar
 
-The sidebar starts shown whenever the extension initializes. An explicit `off` applies only to the current runtime; `/reload` restores the default shown state. Use these commands to control it explicitly:
+The sidebar starts closed by default. Use these commands or the `alt+a` settings menu to control it for the current session. Set `sidebarOpen` to `true` in user configuration to open it automatically in future sessions:
 
 ```text
 /atelier sidebar       # toggle between shown and hidden
@@ -186,6 +186,7 @@ Complete example:
   "currencyDecimals": 3,
   "showExtensionStatuses": true,
   "showSessionActions": true,
+  "sidebarOpen": false,
   "showSidebarToolNames": false,
   "completionNotifications": true
 }

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -419,7 +419,7 @@ export default function atelierExtension(
 			}
 			if (enabled && isFresh()) {
 				installFooter(initializationContext, candidateRuntime, initializationGeneration);
-				localSidebar.show();
+				if (loaded.config.sidebarOpen) localSidebar.show();
 			}
 			void candidateRuntime.refreshWorkspacePulse();
 		} catch (error) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -103,6 +103,7 @@ export function validateConfig(input: unknown, base: AtelierConfig = DEFAULT_CON
 	for (const key of [
 		"showExtensionStatuses",
 		"showSessionActions",
+		"sidebarOpen",
 		"showSidebarToolNames",
 		"completionNotifications",
 	] as const) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface AtelierConfig {
 	currencyDecimals: number;
 	showExtensionStatuses: boolean;
 	showSessionActions: boolean;
+	sidebarOpen: boolean;
 	showSidebarToolNames: boolean;
 	completionNotifications: boolean;
 }
@@ -66,6 +67,7 @@ export const DEFAULT_CONFIG: AtelierConfig = {
 	currencyDecimals: 3,
 	showExtensionStatuses: true,
 	showSessionActions: true,
+	sidebarOpen: false,
 	showSidebarToolNames: false,
 	completionNotifications: true,
 };

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -18,8 +18,9 @@ beforeEach(async () => {
 });
 
 describe("configuration", () => {
-	it("defaults to no brand ornament, collapsed tool details, and completion notifications", () => {
+	it("defaults to no brand ornament, a closed sidebar, collapsed tool details, and completion notifications", () => {
 		expect(DEFAULT_CONFIG.ornament).toBe("none");
+		expect(DEFAULT_CONFIG.sidebarOpen).toBe(false);
 		expect(DEFAULT_CONFIG.showSidebarToolNames).toBe(false);
 		expect(DEFAULT_CONFIG.completionNotifications).toBe(true);
 	});
@@ -87,11 +88,21 @@ describe("configuration", () => {
 
 	it("validates boolean preferences", () => {
 		expect(
-			validateConfig({ showSidebarToolNames: true, completionNotifications: false }).config,
-		).toMatchObject({ showSidebarToolNames: true, completionNotifications: false });
-		const invalid = validateConfig({ showSidebarToolNames: "yes", completionNotifications: "yes" });
+			validateConfig({
+				sidebarOpen: true,
+				showSidebarToolNames: true,
+				completionNotifications: false,
+			}).config,
+		).toMatchObject({ sidebarOpen: true, showSidebarToolNames: true, completionNotifications: false });
+		const invalid = validateConfig({
+			sidebarOpen: "yes",
+			showSidebarToolNames: "yes",
+			completionNotifications: "yes",
+		});
+		expect(invalid.config.sidebarOpen).toBe(false);
 		expect(invalid.config.showSidebarToolNames).toBe(false);
 		expect(invalid.config.completionNotifications).toBe(true);
+		expect(invalid.warnings).toContain("sidebarOpen must be boolean");
 		expect(invalid.warnings).toContain("showSidebarToolNames must be boolean");
 		expect(invalid.warnings).toContain("completionNotifications must be boolean");
 	});

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -196,9 +196,11 @@ describe("extension registration", () => {
 		expect(h.setFooter).not.toHaveBeenCalled();
 	});
 
-	it("starts enabled and toggles the persistent sidebar on -> off -> on", async () => {
+	it("starts with the sidebar closed and toggles it on -> off -> on", async () => {
 		const h = harness();
 		await start(h);
+		expect(h.overlays).toHaveLength(0);
+		await command(h, "sidebar");
 		expect(h.overlays).toHaveLength(1);
 		expect(h.overlays[0]?.options).toMatchObject({
 			overlay: true,
@@ -251,7 +253,7 @@ describe("extension registration", () => {
 		await start(h);
 		await command(h, args);
 		expect(h.ctx.ui.notify).toHaveBeenCalledWith("Usage: /atelier sidebar [on|off]", "warning");
-		expect(h.custom).toHaveBeenCalledOnce();
+		expect(h.custom).not.toHaveBeenCalled();
 	});
 
 	it("warns for invalid sidebar tool-list syntax", async () => {


### PR DESCRIPTION
## Summary

- Add `sidebarOpen` configuration, defaulting to `false`
- Keep the sidebar closed when a new TUI session starts unless `sidebarOpen` is enabled
- Validate `sidebarOpen` as a boolean and document it in the configuration example
- Update configuration and extension behavior tests

## Usage

Set this in `~/.pi/agent/pi-atelier.json` to restore automatic sidebar expansion:

```json
{
  "sidebarOpen": true
}
```

The /atelier sidebar command and the settings menu can still open or close the sidebar during the current session.