### PR TITLE
feat: add live Display Settings Workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add the responsive Display Settings Workspace with the real Status Rail preview, continuous preset/density/Segment editing, provenance, Session overrides, one-step Undo, Revert, and atomic User-default Save.
+- Replace the mixed root menu with a partitioned Atelier Control Center for Settings, Controls, and Actions, and add the direct `/atelier display` route.
+- Keep legacy `segments`, `ornament`, and `showExtensionStatuses` configuration load-compatible while making normalized `segmentLayout` the sole Brand and Statuses visibility source.
 - Add an opt-in `performance` Status Rail segment for live TTFT and estimated/final TPS, while preserving the existing default presets.
 
 ## 0.6.0 — 2026-07-29

--- a/README.md
+++ b/README.md
@@ -171,37 +171,34 @@ Complete example:
 {
   "preset": "editorial",
   "shortcut": "alt+a",
-  "segments": [
-    "brand",
-    "activity",
-    "metrics",
-    "context",
-    "model",
-    "git",
-    "statuses",
-    "menu"
-  ],
   "density": "comfortable",
-  "ornament": "none",
+  "segmentLayout": [
+    { "id": "brand", "visible": false },
+    { "id": "activity", "visible": true },
+    { "id": "metrics", "visible": true },
+    { "id": "performance", "visible": false },
+    { "id": "context", "visible": true },
+    { "id": "model", "visible": true },
+    { "id": "git", "visible": true },
+    { "id": "statuses", "visible": true },
+    { "id": "menu", "visible": true }
+  ],
   "contextWarning": 70,
   "contextDanger": 90,
   "currencyDecimals": 3,
-  "showExtensionStatuses": true,
   "showSessionActions": true,
   "showSidebarToolNames": false,
   "completionNotifications": true
 }
 ```
 
-Unknown or invalid values are ignored with one warning. The required `metrics` and `context` segments are restored if omitted. Add `"performance"` to `segments` to show `TTFT` and `TPS` in the Status Rail; the segment is opt-in and is omitted from all presets by default:
+`segmentLayout` is ordered and every entry has explicit visibility. Pi Atelier preserves the first valid occurrence of each known ID, appends omitted IDs in Product order, and repairs `metrics` and `context` to visible without moving them. Unknown, duplicate, or malformed values produce one de-duplicated warning. Brand and extension Statuses rendering is controlled only by this normalized layout. Performance remains available for TTFT/TPS telemetry but is hidden in all three compatibility templates.
 
-```json
-{
-  "segments": ["activity", "metrics", "performance", "context", "model", "menu"]
-}
-```
+Product defaults are layered with User, trusted Project, then Session settings. Pi Atelier tracks the source of density, preset identity, layout order, and each visibility value; untrusted project configuration is not read. Transitional menu changes are Session-scoped until **Save as user default** atomically patches `preset`, `density`, and `segmentLayout` while preserving unrelated keys. Any density, order, or visibility combination that does not exactly match a complete template has the `custom` preset identity; restoring an exact template restores its named identity.
 
-During streaming, TPS is prefixed with `~` while it is estimated, then replaced with final throughput when the response ends. Each value is dimmed to `~` until it is measured. Enabling the segment from **Toggle segments** appends it to the end of the rail; edit `segments` or use **Reorder segments** to place it elsewhere. The editorial preset always suppresses the brand ornament; `restrained` displays `ATELIER` only for non-editorial configurations that include the `brand` segment.
+Legacy `segments`, `ornament`, and `showExtensionStatuses` keys are still accepted while loading JSON and translated into a complete normalized layout. A usable `segmentLayout` is authoritative over those keys in the same layer. Legacy omitted segments remain present but hidden; legacy Brand and Statuses combinations retain their prior visible result. New configuration should use `segmentLayout`.
+
+During streaming, TPS is prefixed with `~` while it is estimated, then replaced with final throughput when the response ends. Each value is dimmed to `~` until it is measured. Visibility toggles retain an entry's position, and reordering includes hidden entries.
 
 ## Presets
 

--- a/README.md
+++ b/README.md
@@ -97,14 +97,19 @@ Open Pi Atelier with:
 /atelier
 ```
 
-The default shortcut is `alt+a`. The menu contains:
+The default shortcut is `alt+a`. Both entry points open the partitioned **Atelier Control Center**:
 
-- **Model** — choose an authenticated model or thinking level
-- **Tools** — search and toggle active Pi tools
-- **Display** — switch presets and save user defaults
-- **Session** — inspect, rename, or compact the current session
-- **Sidebar** — show or hide the docked information rail and expand or collapse tool-name details
-- **Completion notifications** — enable or disable native system notifications on macOS and Windows
+- **Settings** — the Display Settings Workspace, completion notifications, and the persisted sidebar tool-list preference
+- **Controls** — session-scoped Sidebar visibility, model/thinking selection, and active tools
+- **Actions** — session details, rename, and safe compaction
+
+Open the Display Settings Workspace directly with:
+
+```text
+/atelier display
+```
+
+The workspace shows the real Status Rail renderer as a representative preview. Use Up/Down to select, Enter or Space to change a preset, density, or optional Segment, and Shift+Up/Shift+Down to reorder any Segment (including required `metrics` and `context`). `U` performs one-step Undo, `R` reverts Display Session overrides to the Effective lower-layer baseline, `S` saves the current Display as the User default, and Escape closes while retaining active Session overrides. Preset application is one atomic mutation, and Save keeps the workspace open so its result or any failure remains visible.
 
 Additional commands:
 
@@ -194,9 +199,9 @@ Complete example:
 
 `segmentLayout` is ordered and every entry has explicit visibility. Pi Atelier preserves the first valid occurrence of each known ID, appends omitted IDs in Product order, and repairs `metrics` and `context` to visible without moving them. Unknown, duplicate, or malformed values produce one de-duplicated warning. Brand and extension Statuses rendering is controlled only by this normalized layout. Performance remains available for TTFT/TPS telemetry but is hidden in all three compatibility templates.
 
-Product defaults are layered with User, trusted Project, then Session settings. Pi Atelier tracks the source of density, preset identity, layout order, and each visibility value; untrusted project configuration is not read. Transitional menu changes are Session-scoped until **Save as user default** atomically patches `preset`, `density`, and `segmentLayout` while preserving unrelated keys. Any density, order, or visibility combination that does not exactly match a complete template has the `custom` preset identity; restoring an exact template restores its named identity.
+Product defaults are layered with **User default**, trusted **Project override**, then **Session overrides**. The resulting value is the **Effective baseline** shown by the workspace. Pi Atelier tracks the source of density, preset identity, layout order, and each visibility value; untrusted project configuration is not read. Workspace changes are Session-scoped and immediately update the live rail. **Save** atomically patches only `preset`, `density`, and a cloned `segmentLayout` into User configuration while preserving unrelated and unknown keys; it never writes Project configuration. **Revert** clears only Display Session fields, and one-step **Undo** restores the raw Session snapshot, including after Revert. Any density, order, or visibility combination that does not exactly match a complete template has the `custom` preset identity; restoring an exact template restores its named identity.
 
-Legacy `segments`, `ornament`, and `showExtensionStatuses` keys are still accepted while loading JSON and translated into a complete normalized layout. A usable `segmentLayout` is authoritative over those keys in the same layer. Legacy omitted segments remain present but hidden; legacy Brand and Statuses combinations retain their prior visible result. New configuration should use `segmentLayout`.
+Legacy `segments`, `ornament`, and `showExtensionStatuses` keys remain load-compatible and are translated into a complete normalized layout. A usable `segmentLayout` is authoritative over those keys in the same layer. Legacy omitted segments remain present but hidden; legacy Brand and Statuses combinations retain their prior visible result. Brand and Statuses have no overlapping runtime gates: normalized `segmentLayout` is the sole visibility source. New configuration should use `segmentLayout`.
 
 During streaming, TPS is prefixed with `~` while it is estimated, then replaced with final throughput when the response ends. Each value is dimmed to `~` until it is measured. Visibility toggles retain an entry's position, and reordering includes hidden entries.
 

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -16,7 +16,7 @@ import {
 } from "../src/completion-notifier.js";
 import { loadConfig, saveUserConfig, saveUserConfigPatch } from "../src/config.js";
 import { createFooterComponent, type ThemeLike } from "../src/footer.js";
-import { openAtelierMenu } from "../src/menu.js";
+import { openAtelierControlCenter, openDisplaySettingsWorkspace } from "../src/menu.js";
 import { createRunActivityTracker, type RunActivityTracker } from "../src/run-activity.js";
 import {
 	buildSidebarSnapshot,
@@ -38,7 +38,7 @@ export default function atelierExtension(
 	pi: ExtensionAPI,
 	dependencies: AtelierExtensionDependencies = {},
 ): void {
-	const saveConfig = dependencies.saveConfig ?? saveUserConfig;
+	const _saveConfig = dependencies.saveConfig ?? saveUserConfig;
 	const saveConfigPatch = dependencies.saveConfigPatch ?? saveUserConfigPatch;
 	let runtime: AtelierRuntime | undefined;
 	let currentContext: ExtensionContext | undefined;
@@ -155,13 +155,18 @@ export default function atelierExtension(
 	}
 
 	async function openMenu(ctx: ExtensionContext): Promise<void> {
-		if (!runtime || !sidebar) {
+		const current = getCurrentContextState(ctx);
+		if (!current?.runtime || !current.sidebar) {
 			ctx.ui.notify("Pi Atelier is not active in this session", "warning");
 			return;
 		}
-		const targetRuntime = runtime;
-		const targetSidebar = sidebar;
-		await openAtelierMenu(
+		const targetRuntime = current.runtime;
+		const targetSidebar = current.sidebar;
+		const guardedSavePatch: typeof saveUserConfigPatch = async (path, patch) => {
+			if (runtime !== targetRuntime) throw new Error("Pi Atelier is not active in this session");
+			await saveConfigPatch(path, patch);
+		};
+		await openAtelierControlCenter(
 			pi,
 			ctx,
 			targetRuntime,
@@ -172,8 +177,46 @@ export default function atelierExtension(
 				isToolListExpanded: () => targetRuntime.getConfig().showSidebarToolNames,
 				toggleToolList: async () => setSidebarToolNames(ctx, undefined, targetRuntime, targetSidebar),
 			},
-			saveConfig,
-			saveConfigPatch,
+			requestAllRenders,
+			guardedSavePatch,
+		);
+	}
+
+	async function openDisplay(ctx: ExtensionContext): Promise<void> {
+		if (ctx.mode !== "tui") {
+			ctx.ui.notify("Pi Atelier Display settings require TUI mode", "warning");
+			return;
+		}
+		const current = getCurrentContextState(ctx);
+		if (!current?.runtime) {
+			ctx.ui.notify("Pi Atelier is not active in this session", "warning");
+			return;
+		}
+		const targetRuntime = current.runtime;
+		const guardedSavePatch: typeof saveUserConfigPatch = async (path, patch) => {
+			if (runtime !== targetRuntime) throw new Error("Pi Atelier is not active in this session");
+			await saveConfigPatch(path, patch);
+		};
+		await openDisplaySettingsWorkspace(
+			ctx,
+			{
+				getConfig: () => targetRuntime.getConfig(),
+				getDisplaySettings: () => targetRuntime.getDisplaySettings(),
+				getDisplayProvenance: () => targetRuntime.getDisplayProvenance(),
+				getSessionDisplayOverride: () => targetRuntime.getSessionDisplayOverride(),
+				replaceSessionDisplayOverride: (value) => {
+					if (runtime === targetRuntime) targetRuntime.replaceSessionDisplayOverride(value);
+				},
+				clearSessionDisplayOverride: () => {
+					if (runtime === targetRuntime) targetRuntime.clearSessionDisplayOverride();
+				},
+				applySavedUserDisplayPatch: (patch) => {
+					if (runtime === targetRuntime) targetRuntime.applySavedUserDisplayPatch(patch);
+				},
+			},
+			join(getAgentDir(), "pi-atelier.json"),
+			requestAllRenders,
+			guardedSavePatch,
 		);
 	}
 
@@ -223,6 +266,14 @@ export default function atelierExtension(
 		handler: async (args, ctx) => {
 			const parts = args.trim().toLowerCase().split(/\s+/).filter(Boolean);
 			const [action, sidebarAction, ...extra] = parts;
+			if (action === "display") {
+				if (sidebarAction !== undefined || extra.length > 0) {
+					ctx.ui.notify("Usage: /atelier display", "warning");
+					return;
+				}
+				await openDisplay(ctx);
+				return;
+			}
 			if (action === "sidebar") {
 				if (ctx.mode !== "tui") {
 					ctx.ui.notify("Pi Atelier sidebar requires TUI mode", "warning");

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -1,17 +1,17 @@
 import { basename, join } from "node:path";
 import {
 	CONFIG_DIR_NAME,
-	estimateTokens,
 	type ExtensionAPI,
 	type ExtensionContext,
+	estimateTokens,
 	getAgentDir,
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent";
 import type { KeyId } from "@earendil-works/pi-tui";
 import {
-	createCompletionNotifier,
 	type CompletionNotification,
 	type CompletionNotifier,
+	createCompletionNotifier,
 	type SpawnNotificationProcess,
 } from "../src/completion-notifier.js";
 import { loadConfig, saveUserConfig, saveUserConfigPatch } from "../src/config.js";
@@ -60,6 +60,12 @@ export default function atelierExtension(
 		requestRender();
 		sidebar?.requestRender();
 	};
+	const lifecycleGuardedSavePatch =
+		(targetRuntime: AtelierRuntime): typeof saveUserConfigPatch =>
+		async (path, patch) => {
+			if (runtime !== targetRuntime) throw new Error("Pi Atelier is not active in this session");
+			await saveConfigPatch(path, patch);
+		};
 
 	function updateExtensionStatuses(next: readonly string[]): void {
 		if (
@@ -162,10 +168,6 @@ export default function atelierExtension(
 		}
 		const targetRuntime = current.runtime;
 		const targetSidebar = current.sidebar;
-		const guardedSavePatch: typeof saveUserConfigPatch = async (path, patch) => {
-			if (runtime !== targetRuntime) throw new Error("Pi Atelier is not active in this session");
-			await saveConfigPatch(path, patch);
-		};
 		await openAtelierControlCenter(
 			pi,
 			ctx,
@@ -178,7 +180,7 @@ export default function atelierExtension(
 				toggleToolList: async () => setSidebarToolNames(ctx, undefined, targetRuntime, targetSidebar),
 			},
 			requestAllRenders,
-			guardedSavePatch,
+			lifecycleGuardedSavePatch(targetRuntime),
 		);
 	}
 
@@ -193,10 +195,6 @@ export default function atelierExtension(
 			return;
 		}
 		const targetRuntime = current.runtime;
-		const guardedSavePatch: typeof saveUserConfigPatch = async (path, patch) => {
-			if (runtime !== targetRuntime) throw new Error("Pi Atelier is not active in this session");
-			await saveConfigPatch(path, patch);
-		};
 		await openDisplaySettingsWorkspace(
 			ctx,
 			{
@@ -216,7 +214,7 @@ export default function atelierExtension(
 			},
 			join(getAgentDir(), "pi-atelier.json"),
 			requestAllRenders,
-			guardedSavePatch,
+			lifecycleGuardedSavePatch(targetRuntime),
 		);
 	}
 

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -127,7 +127,7 @@ export default function atelierExtension(
 			targetRuntime.setConfig({ ...targetRuntime.getConfig(), showSidebarToolNames: next });
 		}
 		try {
-			await saveConfig(join(getAgentDir(), "pi-atelier.json"), targetRuntime.getConfig());
+			await saveConfigPatch(join(getAgentDir(), "pi-atelier.json"), { showSidebarToolNames: next });
 			ctx.ui.notify(`Sidebar tool list ${next ? "expanded" : "collapsed"}`, "info");
 		} catch (error) {
 			ctx.ui.notify(
@@ -314,6 +314,8 @@ export default function atelierExtension(
 				pi,
 				ctx: initializationContext,
 				config: loaded.config,
+				displayLayers: loaded.displayLayers,
+				displayProvenance: loaded.displayProvenance,
 				autoCompact,
 				requestRender: () => {
 					if (isFresh() && runtime === localRuntime) requestAllRenders();

--- a/scripts/verify-pack.mjs
+++ b/scripts/verify-pack.mjs
@@ -11,6 +11,7 @@ const required = [
 	"extensions/index.ts",
 	"src/metrics.ts",
 	"src/config.ts",
+	"src/display.ts",
 	"src/footer.ts",
 	"src/state.ts",
 	"src/menu.ts",

--- a/scripts/verify-pack.mjs
+++ b/scripts/verify-pack.mjs
@@ -15,6 +15,7 @@ const required = [
 	"src/footer.ts",
 	"src/state.ts",
 	"src/menu.ts",
+	"src/settings-workspace.ts",
 	"src/palette.ts",
 	"src/run-activity.ts",
 	"assets/preview.png",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,128 +1,318 @@
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import { DEFAULT_CONFIG, type AtelierConfig, type SegmentId } from "./types.js";
+import {
+	derivePresetIdentity,
+	isSegmentId,
+	legacySegmentsToLayout,
+	normalizeSegmentLayout,
+	PRODUCT_SEGMENT_ORDER,
+} from "./display.js";
+import {
+	DEFAULT_CONFIG,
+	type AtelierConfig,
+	type ConfigurationSource,
+	type DisplayLayerState,
+	type DisplayProvenance,
+	type DisplaySettings,
+	type PresetName,
+	type SegmentId,
+	type SegmentLayout,
+} from "./types.js";
 
 export interface ConfigLoadResult {
 	config: AtelierConfig;
 	warnings: string[];
+	displayLayers: DisplayLayerState;
+	displayProvenance: DisplayProvenance;
 }
 
 export interface LoadConfigOptions {
 	userPath: string;
 	projectPath: string;
 	projectTrusted: boolean;
-	session?: Partial<AtelierConfig>;
+	session?: Record<string, unknown> | Partial<AtelierConfig>;
 }
 
-const presets = new Set(["editorial", "minimal", "classic"]);
+const presets = new Set<PresetName>(["editorial", "minimal", "classic", "custom"]);
 const densities = new Set(["comfortable", "compact"]);
 const ornaments = new Set(["none", "restrained"]);
-const segmentIds = new Set<SegmentId>([
-	"brand",
-	"activity",
-	"metrics",
-	"performance",
-	"context",
-	"model",
-	"git",
-	"statuses",
-	"menu",
-]);
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null && !Array.isArray(value);
 
-export function validateConfig(input: unknown, base: AtelierConfig = DEFAULT_CONFIG): ConfigLoadResult {
-	const config: AtelierConfig = { ...base, segments: [...base.segments] };
+const record = (value: unknown): Record<string, unknown> | undefined => (isRecord(value) ? value : undefined);
+const cloneConfig = (config: AtelierConfig): AtelierConfig => ({
+	...config,
+	segmentLayout: config.segmentLayout.map((entry) => ({ ...entry })),
+});
+
+interface CompatibilityState {
+	preset: PresetName;
+	ornament: "none" | "restrained";
+	brandListed: boolean;
+	statusesListed: boolean;
+	showStatuses: boolean;
+}
+
+interface DisplayResolution {
+	display: DisplaySettings;
+	provenance: DisplayProvenance;
+	warnings: string[];
+}
+
+function parsePersistedLayout(value: unknown, warnings: string[]): SegmentLayout | undefined {
+	if (!Array.isArray(value)) {
+		warnings.push("segmentLayout must be an array");
+		return undefined;
+	}
+	const seen = new Set<SegmentId>();
+	const entries: SegmentLayout = [];
+	for (const item of value) {
+		if (!isRecord(item) || !isSegmentId(item.id)) {
+			warnings.push(
+				isRecord(item) && "id" in item
+					? `Unknown segmentLayout segment: ${String(item.id)}`
+					: "Ignoring malformed segmentLayout entry",
+			);
+			continue;
+		}
+		if (seen.has(item.id)) {
+			warnings.push(`Ignoring duplicate segmentLayout segment: ${item.id}`);
+			continue;
+		}
+		seen.add(item.id);
+		let visible = item.visible;
+		if (typeof visible !== "boolean") {
+			warnings.push(`segmentLayout visibility for ${item.id} must be boolean; using hidden`);
+			visible = false;
+		}
+		entries.push({ id: item.id, visible: visible === true });
+	}
+	return normalizeSegmentLayout(entries);
+}
+
+function parseLegacySegments(value: unknown, warnings: string[]): SegmentLayout | undefined {
+	if (!Array.isArray(value)) {
+		warnings.push("segments must be an array");
+		return undefined;
+	}
+	const seen = new Set<SegmentId>();
+	const valid: SegmentId[] = [];
+	for (const item of value) {
+		if (!isSegmentId(item)) {
+			warnings.push(`Unknown segment: ${String(item)}`);
+			continue;
+		}
+		if (seen.has(item)) {
+			warnings.push(`Ignoring duplicate segment: ${item}`);
+			continue;
+		}
+		seen.add(item);
+		valid.push(item);
+	}
+	return legacySegmentsToLayout(valid);
+}
+
+export function resolveDisplayLayers(layers: DisplayLayerState): DisplayResolution {
+	let display: DisplaySettings = {
+		preset: DEFAULT_CONFIG.preset,
+		density: DEFAULT_CONFIG.density,
+		segmentLayout: DEFAULT_CONFIG.segmentLayout.map((entry) => ({ ...entry })),
+	};
+	const visibility = Object.fromEntries(PRODUCT_SEGMENT_ORDER.map((id) => [id, "product"])) as Record<
+		SegmentId,
+		ConfigurationSource
+	>;
+	const provenance: DisplayProvenance = {
+		preset: "product",
+		density: "product",
+		order: "product",
+		visibility,
+	};
+	const compatibility: CompatibilityState = {
+		preset: "editorial",
+		ornament: "none",
+		brandListed: true,
+		statusesListed: true,
+		showStatuses: true,
+	};
 	const warnings: string[] = [];
+
+	for (const [source, input] of [
+		["user", layers.user],
+		["project", layers.project],
+		["session", layers.session],
+	] as const) {
+		if (!input) continue;
+		let changedTemplateField = false;
+		let suppliedPreset = false;
+		if ("preset" in input) {
+			if (typeof input.preset === "string" && presets.has(input.preset as PresetName)) {
+				compatibility.preset = input.preset as PresetName;
+				display.preset = input.preset as PresetName;
+				provenance.preset = source;
+				suppliedPreset = true;
+			} else
+				warnings.push(
+					typeof input.preset === "string" ? `Unknown preset: ${input.preset}` : "preset must be a string",
+				);
+		}
+		if ("density" in input) {
+			if (typeof input.density === "string" && densities.has(input.density)) {
+				display.density = input.density as AtelierConfig["density"];
+				provenance.density = source;
+				changedTemplateField = true;
+			} else
+				warnings.push(
+					typeof input.density === "string"
+						? `Unknown density: ${input.density}`
+						: "density must be a string",
+				);
+		}
+
+		let authoritative = false;
+		let legacySegmentsApplied = false;
+		if ("segmentLayout" in input) {
+			const parsed = parsePersistedLayout(input.segmentLayout, warnings);
+			if (parsed) {
+				display.segmentLayout = parsed;
+				provenance.order = source;
+				for (const id of PRODUCT_SEGMENT_ORDER) provenance.visibility[id] = source;
+				compatibility.brandListed = parsed.find((entry) => entry.id === "brand")?.visible ?? false;
+				compatibility.statusesListed = parsed.find((entry) => entry.id === "statuses")?.visible ?? false;
+				authoritative = true;
+				changedTemplateField = true;
+			}
+		}
+		if (!authoritative && "segments" in input) {
+			const parsed = parseLegacySegments(input.segments, warnings);
+			if (parsed) {
+				display.segmentLayout = parsed;
+				provenance.order = source;
+				for (const id of PRODUCT_SEGMENT_ORDER) provenance.visibility[id] = source;
+				compatibility.brandListed = parsed.find((entry) => entry.id === "brand")?.visible ?? false;
+				compatibility.statusesListed = parsed.find((entry) => entry.id === "statuses")?.visible ?? false;
+				changedTemplateField = true;
+				legacySegmentsApplied = true;
+			}
+		}
+
+		if (!authoritative) {
+			let brandCompatibilityChanged = suppliedPreset || legacySegmentsApplied;
+			if ("ornament" in input) {
+				if (typeof input.ornament === "string" && ornaments.has(input.ornament)) {
+					compatibility.ornament = input.ornament as CompatibilityState["ornament"];
+					brandCompatibilityChanged = true;
+				} else
+					warnings.push(
+						typeof input.ornament === "string"
+							? `Unknown ornament: ${input.ornament}`
+							: "ornament must be a string",
+					);
+			}
+			if (brandCompatibilityChanged) {
+				const brand = display.segmentLayout.find((entry) => entry.id === "brand");
+				if (brand)
+					brand.visible =
+						compatibility.brandListed &&
+						compatibility.preset !== "editorial" &&
+						compatibility.ornament === "restrained";
+				provenance.visibility.brand = source;
+				changedTemplateField = true;
+			}
+			let statusesCompatibilityChanged = legacySegmentsApplied;
+			if ("showExtensionStatuses" in input) {
+				if (typeof input.showExtensionStatuses === "boolean") {
+					compatibility.showStatuses = input.showExtensionStatuses;
+					statusesCompatibilityChanged = true;
+				} else warnings.push("showExtensionStatuses must be boolean");
+			}
+			if (statusesCompatibilityChanged) {
+				const statuses = display.segmentLayout.find((entry) => entry.id === "statuses");
+				if (statuses) statuses.visible = compatibility.statusesListed && compatibility.showStatuses;
+				provenance.visibility.statuses = source;
+				changedTemplateField = true;
+			}
+		}
+
+		const identity = derivePresetIdentity(display);
+		if (identity !== display.preset) {
+			display.preset = identity;
+			if (changedTemplateField) provenance.preset = source;
+		}
+	}
+	return { display, provenance, warnings: [...new Set(warnings)] };
+}
+
+function applyNonDisplay(input: unknown, config: AtelierConfig, warnings: string[]): void {
 	if (!isRecord(input)) {
 		if (input !== undefined) warnings.push("Configuration must be a JSON object");
-		return { config, warnings };
+		return;
 	}
-
-	if (typeof input.preset === "string") {
-		if (presets.has(input.preset)) config.preset = input.preset as AtelierConfig["preset"];
-		else warnings.push(`Unknown preset: ${input.preset}`);
-	} else if ("preset" in input) warnings.push("preset must be a string");
 	if (typeof input.shortcut === "string") {
 		if (input.shortcut.trim()) config.shortcut = input.shortcut.trim();
 		else warnings.push("Shortcut cannot be empty");
 	} else if ("shortcut" in input) warnings.push("shortcut must be a string");
-	if (typeof input.density === "string") {
-		if (densities.has(input.density)) config.density = input.density as AtelierConfig["density"];
-		else warnings.push(`Unknown density: ${input.density}`);
-	} else if ("density" in input) warnings.push("density must be a string");
-	if (typeof input.ornament === "string") {
-		if (ornaments.has(input.ornament)) config.ornament = input.ornament as AtelierConfig["ornament"];
-		else warnings.push(`Unknown ornament: ${input.ornament}`);
-	} else if ("ornament" in input) warnings.push("ornament must be a string");
-
-	if (Array.isArray(input.segments)) {
-		const seen = new Set<string>();
-		const valid: SegmentId[] = [];
-		for (const value of input.segments) {
-			if (typeof value !== "string" || !segmentIds.has(value as SegmentId)) {
-				warnings.push(`Unknown segment: ${String(value)}`);
-				continue;
-			}
-			if (seen.has(value)) {
-				warnings.push(`Ignoring duplicate segment: ${value}`);
-				continue;
-			}
-			seen.add(value);
-			valid.push(value as SegmentId);
-		}
-		for (const required of ["metrics", "context"] as const) {
-			if (!seen.has(required)) valid.push(required);
-		}
-		config.segments = valid;
-	} else if ("segments" in input) warnings.push("segments must be an array");
-
 	const invalidThresholdType =
 		("contextWarning" in input && typeof input.contextWarning !== "number") ||
 		("contextDanger" in input && typeof input.contextDanger !== "number");
 	const warning = typeof input.contextWarning === "number" ? input.contextWarning : config.contextWarning;
 	const danger = typeof input.contextDanger === "number" ? input.contextDanger : config.contextDanger;
-	if (invalidThresholdType) {
-		warnings.push("context thresholds must be numbers");
-	} else if (warning >= 0 && warning < danger && danger <= 100) {
+	if (invalidThresholdType) warnings.push("context thresholds must be numbers");
+	else if (warning >= 0 && warning < danger && danger <= 100) {
 		config.contextWarning = warning;
 		config.contextDanger = danger;
-	} else if ("contextWarning" in input || "contextDanger" in input) {
+	} else if ("contextWarning" in input || "contextDanger" in input)
 		warnings.push("Invalid context threshold ordering; expected 0 <= warning < danger <= 100");
-	}
-
 	if (typeof input.currencyDecimals === "number") {
 		if (
 			Number.isInteger(input.currencyDecimals) &&
 			input.currencyDecimals >= 0 &&
 			input.currencyDecimals <= 6
-		) {
+		)
 			config.currencyDecimals = input.currencyDecimals;
-		} else warnings.push("currencyDecimals must be an integer from 0 through 6");
+		else warnings.push("currencyDecimals must be an integer from 0 through 6");
 	}
-	for (const key of [
-		"showExtensionStatuses",
-		"showSessionActions",
-		"showSidebarToolNames",
-		"completionNotifications",
-	] as const) {
+	for (const key of ["showSessionActions", "showSidebarToolNames", "completionNotifications"] as const) {
 		if (typeof input[key] === "boolean") config[key] = input[key];
 		else if (key in input) warnings.push(`${key} must be boolean`);
 	}
-	return { config, warnings };
 }
 
-export function mergeConfig(...layers: unknown[]): ConfigLoadResult {
-	let config = { ...DEFAULT_CONFIG, segments: [...DEFAULT_CONFIG.segments] };
+export function validateConfig(input: unknown, base: AtelierConfig = DEFAULT_CONFIG): ConfigLoadResult {
+	const config = cloneConfig(base);
 	const warnings: string[] = [];
-	for (const layer of layers) {
-		if (layer === undefined) continue;
-		const result = validateConfig(layer, config);
-		config = result.config;
-		warnings.push(...result.warnings);
-	}
-	return { config, warnings: [...new Set(warnings)] };
+	applyNonDisplay(input, config, warnings);
+	const inputRecord = record(input);
+	const displayLayers: DisplayLayerState = inputRecord ? { user: inputRecord } : {};
+	const resolved = resolveDisplayLayers(displayLayers);
+	Object.assign(config, resolved.display);
+	return {
+		config,
+		warnings: [...new Set([...warnings, ...resolved.warnings])],
+		displayLayers,
+		displayProvenance: resolved.provenance,
+	};
+}
+
+export function mergeConfig(...inputs: unknown[]): ConfigLoadResult {
+	const config = cloneConfig(DEFAULT_CONFIG);
+	const warnings: string[] = [];
+	for (const input of inputs) applyNonDisplay(input, config, warnings);
+	const records = inputs.map(record).filter((item): item is Record<string, unknown> => !!item);
+	const displayLayers: DisplayLayerState = {
+		...(records[0] ? { user: records[0] } : {}),
+		...(records[1] ? { project: records[1] } : {}),
+		...(records[2] ? { session: records[2] } : {}),
+	};
+	const resolved = resolveDisplayLayers(displayLayers);
+	Object.assign(config, resolved.display);
+	return {
+		config,
+		warnings: [...new Set([...warnings, ...resolved.warnings])],
+		displayLayers,
+		displayProvenance: resolved.provenance,
+	};
 }
 
 async function readJson(path: string): Promise<{ value?: unknown; warning?: string }> {
@@ -137,22 +327,42 @@ async function readJson(path: string): Promise<{ value?: unknown; warning?: stri
 export async function loadConfig(options: LoadConfigOptions): Promise<ConfigLoadResult> {
 	const user = await readJson(options.userPath);
 	const project = options.projectTrusted ? await readJson(options.projectPath) : {};
-	const result = mergeConfig(user.value, project.value, options.session);
-	result.config.completionNotifications = validateConfig(user.value).config.completionNotifications;
+	const config = cloneConfig(DEFAULT_CONFIG);
+	const warnings: string[] = [];
+	applyNonDisplay(user.value, config, warnings);
+	if (options.projectTrusted) applyNonDisplay(project.value, config, warnings);
+	applyNonDisplay(options.session, config, warnings);
+	const userRecord = record(user.value);
+	const projectRecord = options.projectTrusted ? record(project.value) : undefined;
+	const sessionRecord = record(options.session);
+	const displayLayers: DisplayLayerState = {
+		...(userRecord ? { user: userRecord } : {}),
+		...(projectRecord ? { project: projectRecord } : {}),
+		...(sessionRecord ? { session: sessionRecord } : {}),
+	};
+	const resolved = resolveDisplayLayers(displayLayers);
+	Object.assign(config, resolved.display);
+	// Completion notifications are intentionally global-user-only.
+	const global = cloneConfig(DEFAULT_CONFIG);
+	applyNonDisplay(user.value, global, []);
+	config.completionNotifications = global.completionNotifications;
 	return {
-		config: result.config,
+		config,
 		warnings: [
 			...new Set(
-				[user.warning, project.warning, ...result.warnings].filter((item): item is string => !!item),
+				[user.warning, project.warning, ...warnings, ...resolved.warnings].filter(
+					(item): item is string => !!item,
+				),
 			),
 		],
+		displayLayers,
+		displayProvenance: resolved.provenance,
 	};
 }
 
 export async function saveUserConfig(path: string, config: AtelierConfig): Promise<void> {
 	await writeJsonAtomic(path, config);
 }
-
 export async function saveUserConfigPatch(path: string, patch: Partial<AtelierConfig>): Promise<void> {
 	let current: Record<string, unknown> = {};
 	try {
@@ -164,15 +374,11 @@ export async function saveUserConfigPatch(path: string, patch: Partial<AtelierCo
 	}
 	await writeJsonAtomic(path, { ...current, ...patch });
 }
-
 async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
 	await mkdir(dirname(path), { recursive: true });
 	const temporaryPath = `${path}.${process.pid}.tmp`;
 	try {
-		await writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, {
-			encoding: "utf8",
-			mode: 0o600,
-		});
+		await writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
 		await rename(temporaryPath, path);
 	} finally {
 		await rm(temporaryPath, { force: true }).catch(() => undefined);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import {
+	applyDisplayTemplate,
 	derivePresetIdentity,
 	isSegmentId,
 	legacySegmentsToLayout,
@@ -17,6 +18,7 @@ import {
 	type PresetName,
 	type SegmentId,
 	type SegmentLayout,
+	type TemplateName,
 } from "./types.js";
 
 export interface ConfigLoadResult {
@@ -113,11 +115,14 @@ function parseLegacySegments(value: unknown, warnings: string[]): SegmentLayout 
 	return legacySegmentsToLayout(valid);
 }
 
-export function resolveDisplayLayers(layers: DisplayLayerState): DisplayResolution {
+export function resolveDisplayLayers(
+	layers: DisplayLayerState,
+	base: DisplaySettings = DEFAULT_CONFIG,
+): DisplayResolution {
 	let display: DisplaySettings = {
-		preset: DEFAULT_CONFIG.preset,
-		density: DEFAULT_CONFIG.density,
-		segmentLayout: DEFAULT_CONFIG.segmentLayout.map((entry) => ({ ...entry })),
+		preset: base.preset,
+		density: base.density,
+		segmentLayout: base.segmentLayout.map((entry) => ({ ...entry })),
 	};
 	const visibility = Object.fromEntries(PRODUCT_SEGMENT_ORDER.map((id) => [id, "product"])) as Record<
 		SegmentId,
@@ -152,6 +157,13 @@ export function resolveDisplayLayers(layers: DisplayLayerState): DisplayResoluti
 				display.preset = input.preset as PresetName;
 				provenance.preset = source;
 				suppliedPreset = true;
+				if (input.preset !== "custom") {
+					display = applyDisplayTemplate(input.preset as TemplateName);
+					provenance.density = source;
+					provenance.order = source;
+					for (const id of PRODUCT_SEGMENT_ORDER) provenance.visibility[id] = source;
+					changedTemplateField = true;
+				}
 			} else
 				warnings.push(
 					typeof input.preset === "string" ? `Unknown preset: ${input.preset}` : "preset must be a string",
@@ -285,7 +297,7 @@ export function validateConfig(input: unknown, base: AtelierConfig = DEFAULT_CON
 	applyNonDisplay(input, config, warnings);
 	const inputRecord = record(input);
 	const displayLayers: DisplayLayerState = inputRecord ? { user: inputRecord } : {};
-	const resolved = resolveDisplayLayers(displayLayers);
+	const resolved = resolveDisplayLayers(displayLayers, base);
 	Object.assign(config, resolved.display);
 	return {
 		config,

--- a/src/display.ts
+++ b/src/display.ts
@@ -1,0 +1,153 @@
+import type {
+	Density,
+	DisplaySettings,
+	PresetName,
+	SegmentId,
+	SegmentLayout,
+	TemplateName,
+} from "./types.js";
+
+export const PRODUCT_SEGMENT_ORDER = [
+	"brand",
+	"activity",
+	"metrics",
+	"performance",
+	"context",
+	"model",
+	"git",
+	"statuses",
+	"menu",
+] as const satisfies readonly SegmentId[];
+
+export const REQUIRED_SEGMENT_IDS = ["metrics", "context"] as const satisfies readonly SegmentId[];
+const SEGMENT_IDS = new Set<string>(PRODUCT_SEGMENT_ORDER);
+
+const layout = (visible: readonly SegmentId[]): SegmentLayout => {
+	const shown = new Set(visible);
+	return PRODUCT_SEGMENT_ORDER.map((id) => ({ id, visible: shown.has(id) }));
+};
+
+export interface DisplayTemplate {
+	preset: TemplateName;
+	density: Density;
+	segmentLayout: SegmentLayout;
+}
+
+export const DISPLAY_TEMPLATES: Record<TemplateName, DisplayTemplate> = {
+	editorial: {
+		preset: "editorial",
+		density: "comfortable",
+		segmentLayout: layout(["activity", "metrics", "context", "model", "git", "statuses", "menu"]),
+	},
+	minimal: {
+		preset: "minimal",
+		density: "compact",
+		segmentLayout: layout(["activity", "metrics", "context", "model", "menu"]),
+	},
+	classic: {
+		preset: "classic",
+		density: "comfortable",
+		segmentLayout: layout(["metrics", "context", "model", "git", "statuses"]),
+	},
+};
+
+export const isSegmentId = (value: unknown): value is SegmentId =>
+	typeof value === "string" && SEGMENT_IDS.has(value);
+
+export const cloneSegmentLayout = (value: readonly { id: SegmentId; visible: boolean }[]): SegmentLayout =>
+	value.map((entry) => ({ ...entry }));
+
+export const legacySegmentsToLayout = (segments: readonly SegmentId[]): SegmentLayout => {
+	const seen = new Set<SegmentId>();
+	const result: SegmentLayout = [];
+	for (const id of segments) {
+		if (seen.has(id)) continue;
+		seen.add(id);
+		result.push({ id, visible: true });
+	}
+	for (const id of PRODUCT_SEGMENT_ORDER) {
+		if (!seen.has(id)) result.push({ id, visible: false });
+	}
+	for (const entry of result) {
+		if ((REQUIRED_SEGMENT_IDS as readonly SegmentId[]).includes(entry.id)) entry.visible = true;
+	}
+	return result;
+};
+
+/** Completes already-validated entries without changing their relative order. */
+export const normalizeSegmentLayout = (
+	entries: readonly { id: SegmentId; visible: boolean }[],
+): SegmentLayout => {
+	const seen = new Set<SegmentId>();
+	const result: SegmentLayout = [];
+	for (const entry of entries) {
+		if (seen.has(entry.id)) continue;
+		seen.add(entry.id);
+		result.push({ id: entry.id, visible: entry.visible });
+	}
+	for (const id of PRODUCT_SEGMENT_ORDER) {
+		if (!seen.has(id)) result.push({ id, visible: false });
+	}
+	for (const entry of result) {
+		if ((REQUIRED_SEGMENT_IDS as readonly SegmentId[]).includes(entry.id)) entry.visible = true;
+	}
+	return result;
+};
+
+export const toggleSegmentVisibility = (
+	value: readonly { id: SegmentId; visible: boolean }[],
+	id: SegmentId,
+	visible?: boolean,
+): SegmentLayout =>
+	value.map((entry) => ({
+		...entry,
+		visible:
+			entry.id === id && !(REQUIRED_SEGMENT_IDS as readonly SegmentId[]).includes(id)
+				? (visible ?? !entry.visible)
+				: entry.visible,
+	}));
+
+export const reorderSegment = (
+	value: readonly { id: SegmentId; visible: boolean }[],
+	id: SegmentId,
+	direction: "earlier" | "later",
+): SegmentLayout => {
+	const result = cloneSegmentLayout(value);
+	const index = result.findIndex((entry) => entry.id === id);
+	const target = direction === "earlier" ? index - 1 : index + 1;
+	if (index < 0 || target < 0 || target >= result.length) return result;
+	const current = result[index];
+	const neighbor = result[target];
+	if (!current || !neighbor) return result;
+	result[index] = neighbor;
+	result[target] = current;
+	return result;
+};
+
+const layoutsEqual = (
+	left: readonly { id: SegmentId; visible: boolean }[],
+	right: readonly { id: SegmentId; visible: boolean }[],
+): boolean =>
+	left.length === right.length &&
+	left.every((entry, index) => entry.id === right[index]?.id && entry.visible === right[index]?.visible);
+
+export const derivePresetIdentity = (
+	display: Pick<DisplaySettings, "density" | "segmentLayout">,
+): PresetName => {
+	for (const name of ["editorial", "minimal", "classic"] as const) {
+		const template = DISPLAY_TEMPLATES[name];
+		if (display.density === template.density && layoutsEqual(display.segmentLayout, template.segmentLayout)) {
+			return name;
+		}
+	}
+	return "custom";
+};
+
+export const applyDisplayTemplate = (name: TemplateName): DisplaySettings => {
+	const template = DISPLAY_TEMPLATES[name];
+	return {
+		preset: name,
+		density: template.density,
+		segmentLayout: cloneSegmentLayout(template.segmentLayout),
+	};
+};

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -146,19 +146,19 @@ function buildItems(
 		items.push(compactDensity ? { ...item, full: item.compact } : item);
 	};
 
-	for (const segment of config.segments) {
+	for (const entry of config.segmentLayout) {
+		if (!entry.visible) continue;
+		const segment = entry.id;
 		if (segment === "brand") {
-			if (config.preset !== "editorial" && config.ornament !== "none") {
-				const brand = palette.paint("muted", "ATELIER");
-				add({
-					id: "brand",
-					zone: "left",
-					full: brand,
-					compact: brand,
-					dropRank: DROP.brand,
-					required: false,
-				});
-			}
+			const brand = palette.paint("muted", "ATELIER");
+			add({
+				id: "brand",
+				zone: "left",
+				full: brand,
+				compact: brand,
+				dropRank: DROP.brand,
+				required: false,
+			});
 			continue;
 		}
 
@@ -219,19 +219,17 @@ function buildItems(
 		}
 
 		if (segment === "statuses") {
-			if (config.showExtensionStatuses) {
-				const statuses = state.extensionStatuses.map(sanitize).filter(Boolean).join(" ");
-				if (statuses) {
-					const rendered = palette.paint("muted", statuses);
-					add({
-						id: "status",
-						zone: "left",
-						full: rendered,
-						compact: rendered,
-						dropRank: DROP.status,
-						required: false,
-					});
-				}
+			const statuses = state.extensionStatuses.map(sanitize).filter(Boolean).join(" ");
+			if (statuses) {
+				const rendered = palette.paint("muted", statuses);
+				add({
+					id: "status",
+					zone: "left",
+					full: rendered,
+					compact: rendered,
+					dropRank: DROP.status,
+					required: false,
+				});
 			}
 			continue;
 		}

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -14,6 +14,7 @@ import {
 	visibleWidth,
 } from "@earendil-works/pi-tui";
 import { saveUserConfig, saveUserConfigPatch } from "./config.js";
+import { createSettingsWorkspace } from "./settings-workspace.js";
 import { applyDisplayTemplate, reorderSegment, toggleSegmentVisibility } from "./display.js";
 import type { AtelierRuntime } from "./state.js";
 import type { AtelierConfig, Ornament, SegmentId, TemplateName } from "./types.js";
@@ -282,141 +283,190 @@ async function showToolSettings(
 	);
 }
 
+export async function openDisplaySettingsWorkspace(
+	ctx: ExtensionContext,
+	runtime: Pick<
+		AtelierRuntime,
+		| "getConfig"
+		| "getDisplaySettings"
+		| "getDisplayProvenance"
+		| "getSessionDisplayOverride"
+		| "replaceSessionDisplayOverride"
+		| "clearSessionDisplayOverride"
+		| "applySavedUserDisplayPatch"
+	>,
+	userConfigPath: string,
+	requestAllRenders: () => void,
+	savePatch: SaveConfigPatch = saveUserConfigPatch,
+): Promise<void> {
+	if (ctx.mode !== "tui") {
+		ctx.ui.notify("Pi Atelier Display settings require TUI mode", "warning");
+		return;
+	}
+	await ctx.ui.custom<void>(
+		(tui, theme, _keys, done) =>
+			createSettingsWorkspace({
+				getDisplaySettings: () => runtime.getDisplaySettings(),
+				getDisplayProvenance: () => runtime.getDisplayProvenance(),
+				getSessionDisplayOverride: () => runtime.getSessionDisplayOverride(),
+				replaceSessionDisplayOverride: (value) => runtime.replaceSessionDisplayOverride(value),
+				clearSessionDisplayOverride: () => runtime.clearSessionDisplayOverride(),
+				persistUserDisplayPatch: (patch) => savePatch(userConfigPath, patch),
+				applySavedUserDisplayPatch: (patch) => runtime.applySavedUserDisplayPatch(patch),
+				getRenderConfig: () => runtime.getConfig(),
+				theme,
+				colorEnabled: !("NO_COLOR" in process.env),
+				requestWorkspaceRender: () => tui.requestRender(),
+				requestLiveRender: requestAllRenders,
+				close: () => done(undefined),
+				report: (message, kind) => {
+					if (kind === "error") ctx.ui.notify(message, "error");
+				},
+			}),
+		{
+			overlay: true,
+			overlayOptions: { anchor: "center", width: "90%", minWidth: 36, maxHeight: "95%", margin: 1 },
+		},
+	);
+}
+
+export async function openAtelierControlCenter(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	runtime: AtelierRuntime,
+	userConfigPath: string,
+	sidebar: SidebarControls,
+	requestAllRenders: () => void = () => undefined,
+	savePatch: SaveConfigPatch = saveUserConfigPatch,
+): Promise<void> {
+	if (ctx.mode !== "tui") {
+		ctx.ui.notify("Pi Atelier Control Center requires TUI mode", "warning");
+		return;
+	}
+	const actions = createMenuActions(pi, ctx, runtime, userConfigPath, saveUserConfig, savePatch);
+	for (;;) {
+		const category = await showSelection(ctx, "◆ Atelier Control Center", [
+			{ value: "settings", label: "Settings", description: "Persisted defaults and Display workspace" },
+			{
+				value: "controls",
+				label: "Controls",
+				description: `Session controls · Sidebar: ${sidebar.isVisible() ? "On" : "Off"}`,
+			},
+			{ value: "actions", label: "Actions", description: "Session details, rename, and compaction" },
+			{ value: "close", label: "Close" },
+		]);
+		if (!category || category === "close") return;
+		if (category === "settings") {
+			for (;;) {
+				const choice = await showSelection(ctx, "Settings", [
+					{
+						value: "display",
+						label: `Display: ${runtime.getDisplaySettings().preset}`,
+						description: "Session overrides, preview, Undo, Revert, and Save",
+					},
+					{
+						value: "notifications",
+						label: `Completion notifications: ${runtime.getConfig().completionNotifications ? "On" : "Off"}`,
+						description: "User preference",
+					},
+					{
+						value: "sidebar-tools",
+						label: `Sidebar tool list: ${sidebar.isToolListExpanded() ? "Expanded" : "Collapsed"}`,
+						description: "User preference",
+					},
+					{ value: "back", label: "Back" },
+				]);
+				if (!choice || choice === "back") break;
+				if (choice === "display")
+					await openDisplaySettingsWorkspace(ctx, runtime, userConfigPath, requestAllRenders, savePatch);
+				else if (choice === "notifications")
+					await actions.setCompletionNotifications(!runtime.getConfig().completionNotifications);
+				else await sidebar.toggleToolList();
+			}
+		} else if (category === "controls") {
+			for (;;) {
+				const choice = await showSelection(ctx, "Controls", [
+					{
+						value: "sidebar",
+						label: `Sidebar: ${sidebar.isVisible() ? "On" : "Off"}`,
+						description: "Session control; shown by default",
+					},
+					{
+						value: "model",
+						label: `Model / thinking: ${ctx.model?.id ?? "none"} / ${pi.getThinkingLevel()}`,
+						description: "Session control",
+					},
+					{
+						value: "tools",
+						label: `Active tools: ${pi.getActiveTools().length}`,
+						description: "Session control",
+					},
+					{ value: "back", label: "Back" },
+				]);
+				if (!choice || choice === "back") break;
+				if (choice === "sidebar") sidebar.toggle();
+				else if (choice === "tools") await showToolSettings(ctx, pi, actions.setTools);
+				else {
+					const selected = await ctx.ui.select("Model controls", ["Choose model", "Thinking level", "Back"]);
+					if (selected === "Choose model") {
+						const models = ctx.modelRegistry.getAvailable();
+						const labels = models.map((model) => `${model.provider}/${model.id}`);
+						const model = models[labels.indexOf((await ctx.ui.select("Choose model", labels)) ?? "")];
+						if (model) await actions.selectModel(model);
+					} else if (selected === "Thinking level") {
+						const level = await ctx.ui.select("Thinking level", [
+							"off",
+							"minimal",
+							"low",
+							"medium",
+							"high",
+							"xhigh",
+							"max",
+						]);
+						if (level) actions.setThinkingLevel(level as Parameters<ExtensionAPI["setThinkingLevel"]>[0]);
+					}
+				}
+			}
+		} else {
+			for (;;) {
+				const choice = await showSelection(ctx, "Actions", [
+					{
+						value: "details",
+						label: "Session details",
+						description: ctx.sessionManager.getSessionFile() ?? "Ephemeral session",
+					},
+					...(runtime.getConfig().showSessionActions
+						? [
+								{ value: "rename", label: "Rename session" },
+								{ value: "compact", label: "Compact session" },
+							]
+						: []),
+					{ value: "back", label: "Back" },
+				]);
+				if (!choice || choice === "back") break;
+				if (choice === "details")
+					ctx.ui.notify(
+						ctx.sessionManager.getSessionFile()
+							? `Session: ${ctx.sessionManager.getSessionFile()}`
+							: "Ephemeral session",
+						"info",
+					);
+				else if (choice === "rename") await actions.renameSession();
+				else await actions.compactSession();
+			}
+		}
+	}
+}
+
+/** @deprecated Use openAtelierControlCenter. */
 export async function openAtelierMenu(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
 	runtime: AtelierRuntime,
 	userConfigPath: string,
 	sidebar: SidebarControls,
-	save: SaveConfig = saveUserConfig,
+	_save: SaveConfig = saveUserConfig,
 	savePatch: SaveConfigPatch = saveUserConfigPatch,
 ): Promise<void> {
-	if (ctx.mode !== "tui") {
-		ctx.ui.notify("Pi Atelier menu requires TUI mode", "warning");
-		return;
-	}
-	const actions = createMenuActions(pi, ctx, runtime, userConfigPath, save, savePatch);
-	for (;;) {
-		const sidebarVisible = sidebar.isVisible();
-		const toolListExpanded = sidebar.isToolListExpanded();
-		const notificationsEnabled = runtime.getConfig().completionNotifications;
-		const section = await showSelection(ctx, "◆ Pi Atelier", [
-			{
-				value: "sidebar",
-				label: `Sidebar: ${sidebarVisible ? "On" : "Off"}`,
-				description: sidebarVisible ? "Hide the docked information rail" : "Show the docked information rail",
-			},
-			{
-				value: "sidebar-tools",
-				label: `Tool list: ${toolListExpanded ? "Expanded" : "Collapsed"}`,
-				description: toolListExpanded
-					? "Collapse sidebar tool names"
-					: "Show active tool names in the sidebar",
-			},
-			{
-				value: "notifications",
-				label: `Completion notifications: ${notificationsEnabled ? "On" : "Off"}`,
-				description: "Notify when a turn settles or Pi requests input",
-			},
-			{ value: "model", label: "Model", description: "Model and thinking level" },
-			{ value: "tools", label: "Tools", description: "Search and toggle active tools" },
-			{ value: "display", label: "Display", description: "Preset and footer segments" },
-			{ value: "session", label: "Session", description: "Details, name, and compaction" },
-			{ value: "close", label: "Close" },
-		]);
-		if (!section || section === "close") return;
-
-		if (section === "sidebar") {
-			sidebar.toggle();
-			continue;
-		}
-		if (section === "sidebar-tools") {
-			await sidebar.toggleToolList();
-			continue;
-		}
-		if (section === "notifications") {
-			await actions.setCompletionNotifications(!notificationsEnabled);
-			continue;
-		}
-
-		if (section === "model") {
-			const action = await ctx.ui.select("Model controls", ["Choose model", "Thinking level", "Back"]);
-			if (action === "Choose model") {
-				const models = ctx.modelRegistry.getAvailable();
-				const labels = models.map((model) => `${model.provider}/${model.id}`);
-				const selected = await ctx.ui.select("Choose model", labels);
-				const model = models[labels.indexOf(selected ?? "")];
-				if (model) await actions.selectModel(model);
-			} else if (action === "Thinking level") {
-				const selected = await ctx.ui.select("Thinking level", [
-					"off",
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh",
-					"max",
-				]);
-				if (selected) actions.setThinkingLevel(selected as Parameters<ExtensionAPI["setThinkingLevel"]>[0]);
-			}
-		} else if (section === "tools") {
-			await showToolSettings(ctx, pi, actions.setTools);
-		} else if (section === "display") {
-			const action = await ctx.ui.select("Display controls", [
-				"Editorial preset",
-				"Minimal preset",
-				"Classic preset",
-				"Toggle segments",
-				"Reorder segments",
-				"Density",
-				"Ornament",
-				"Save as user default",
-				"Back",
-			]);
-			if (action?.endsWith("preset")) actions.setPreset(action.split(" ")[0]?.toLowerCase() as TemplateName);
-			else if (action === "Toggle segments") {
-				const current = runtime.getDisplaySettings().segmentLayout;
-				const optional: SegmentId[] = [
-					"brand",
-					"activity",
-					"performance",
-					"model",
-					"git",
-					"statuses",
-					"menu",
-				];
-				const labels = optional.map(
-					(id) => `${current.find((entry) => entry.id === id)?.visible ? "✓" : "○"} ${id}`,
-				);
-				const selected = await ctx.ui.select("Toggle footer segment", labels);
-				const id = optional[labels.indexOf(selected ?? "")];
-				if (id) actions.toggleSegment(id);
-			} else if (action === "Reorder segments") {
-				const current = runtime.getDisplaySettings().segmentLayout;
-				const labels = current.map((entry) => `${entry.visible ? "✓" : "○"} ${entry.id}`);
-				const selected = await ctx.ui.select("Choose segment", labels);
-				if (selected) {
-					const direction = await ctx.ui.select("Move segment", ["earlier", "later"]);
-					const id = current[labels.indexOf(selected)]?.id;
-					if (direction && id) actions.moveSegment(id, direction as "earlier" | "later");
-				}
-			} else if (action === "Density") {
-				const density = await ctx.ui.select("Footer density", ["comfortable", "compact"]);
-				if (density) actions.setDensity(density as AtelierConfig["density"]);
-			} else if (action === "Ornament") {
-				const ornament = await ctx.ui.select("Footer ornament", ["restrained", "none"]);
-				if (ornament) actions.setOrnament(ornament as Ornament);
-			} else if (action === "Save as user default") await actions.saveDisplayDefaults();
-		} else if (section === "session") {
-			const options = runtime.getConfig().showSessionActions
-				? ["Show details", "Rename session", "Compact session", "Back"]
-				: ["Show details", "Back"];
-			const action = await ctx.ui.select("Session controls", options);
-			if (action === "Show details") {
-				const file = ctx.sessionManager.getSessionFile();
-				ctx.ui.notify(file ? `Session: ${file}` : "Ephemeral session", "info");
-			} else if (action === "Rename session") await actions.renameSession();
-			else if (action === "Compact session") await actions.compactSession();
-		}
-	}
+	await openAtelierControlCenter(pi, ctx, runtime, userConfigPath, sidebar, () => undefined, savePatch);
 }

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -14,8 +14,9 @@ import {
 	visibleWidth,
 } from "@earendil-works/pi-tui";
 import { saveUserConfig, saveUserConfigPatch } from "./config.js";
+import { applyDisplayTemplate, reorderSegment, toggleSegmentVisibility } from "./display.js";
 import type { AtelierRuntime } from "./state.js";
-import { DEFAULT_CONFIG, type AtelierConfig, type PresetName, type SegmentId } from "./types.js";
+import type { AtelierConfig, Ornament, SegmentId, TemplateName } from "./types.js";
 
 export type SaveConfig = typeof saveUserConfig;
 export type SaveConfigPatch = typeof saveUserConfigPatch;
@@ -48,28 +49,15 @@ export function renderMenuFrame(theme: MenuTheme, lines: string[], width: number
 	return [border(`┏${"━".repeat(innerWidth)}┓`), ...framed, border(`┗${"━".repeat(innerWidth)}┛`)];
 }
 
-const PRESET_CONFIG: Record<PresetName, Partial<AtelierConfig>> = {
-	editorial: DEFAULT_CONFIG,
-	minimal: {
-		preset: "minimal",
-		segments: ["activity", "metrics", "context", "model", "menu"],
-		density: "compact",
-		ornament: "none",
-	},
-	classic: {
-		preset: "classic",
-		segments: ["metrics", "context", "model", "git", "statuses"],
-		density: "comfortable",
-		ornament: "none",
-	},
-};
-
 export function createMenuActions(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
-	runtime: Pick<AtelierRuntime, "getConfig" | "setConfig" | "refreshUsage">,
+	runtime: Pick<
+		AtelierRuntime,
+		"getConfig" | "setConfig" | "getDisplaySettings" | "setSessionDisplayPatch" | "refreshUsage"
+	>,
 	userConfigPath: string,
-	save: SaveConfig = saveUserConfig,
+	_save: SaveConfig = saveUserConfig,
 	savePatch: SaveConfigPatch = saveUserConfigPatch,
 ) {
 	return {
@@ -123,14 +111,20 @@ export function createMenuActions(
 				);
 			}
 		},
-		setPreset(preset: PresetName): void {
-			runtime.setConfig({ ...runtime.getConfig(), ...PRESET_CONFIG[preset], preset });
+		setPreset(preset: TemplateName): void {
+			runtime.setSessionDisplayPatch(applyDisplayTemplate(preset));
 		},
 		setDensity(density: AtelierConfig["density"]): void {
-			runtime.setConfig({ ...runtime.getConfig(), density });
+			runtime.setSessionDisplayPatch({ density });
 		},
-		setOrnament(ornament: AtelierConfig["ornament"]): void {
-			runtime.setConfig({ ...runtime.getConfig(), ornament });
+		setOrnament(ornament: Ornament): void {
+			runtime.setSessionDisplayPatch({
+				segmentLayout: toggleSegmentVisibility(
+					runtime.getDisplaySettings().segmentLayout,
+					"brand",
+					ornament === "restrained",
+				),
+			});
 		},
 		async setCompletionNotifications(enabled: boolean): Promise<void> {
 			runtime.setConfig({ ...runtime.getConfig(), completionNotifications: enabled });
@@ -147,23 +141,28 @@ export function createMenuActions(
 			}
 		},
 		moveSegment(id: SegmentId, direction: "earlier" | "later"): void {
-			const segments = [...runtime.getConfig().segments];
-			const index = segments.indexOf(id);
-			const target = direction === "earlier" ? index - 1 : index + 1;
-			if (index < 0 || target < 0 || target >= segments.length) return;
-			[segments[index], segments[target]] = [segments[target] as SegmentId, segments[index] as SegmentId];
-			runtime.setConfig({ ...runtime.getConfig(), segments });
+			runtime.setSessionDisplayPatch({
+				segmentLayout: reorderSegment(runtime.getDisplaySettings().segmentLayout, id, direction),
+			});
 		},
 		setSegments(segments: SegmentId[]): void {
-			const required: SegmentId[] = [...segments, "metrics", "context"];
-			runtime.setConfig({
-				...runtime.getConfig(),
-				segments: [...new Set<SegmentId>(required)],
+			const selected = new Set(segments);
+			let layout = runtime
+				.getDisplaySettings()
+				.segmentLayout.map((entry) => ({ ...entry, visible: selected.has(entry.id) }));
+			layout = toggleSegmentVisibility(layout, "metrics", true);
+			layout = toggleSegmentVisibility(layout, "context", true);
+			runtime.setSessionDisplayPatch({ segmentLayout: layout });
+		},
+		toggleSegment(id: SegmentId): void {
+			runtime.setSessionDisplayPatch({
+				segmentLayout: toggleSegmentVisibility(runtime.getDisplaySettings().segmentLayout, id),
 			});
 		},
 		async saveDisplayDefaults(): Promise<void> {
 			try {
-				await save(userConfigPath, runtime.getConfig());
+				const display = runtime.getDisplaySettings();
+				await savePatch(userConfigPath, display);
 				ctx.ui.notify("Pi Atelier display defaults saved", "info");
 			} catch (error) {
 				ctx.ui.notify(
@@ -374,9 +373,9 @@ export async function openAtelierMenu(
 				"Save as user default",
 				"Back",
 			]);
-			if (action?.endsWith("preset")) actions.setPreset(action.split(" ")[0]?.toLowerCase() as PresetName);
+			if (action?.endsWith("preset")) actions.setPreset(action.split(" ")[0]?.toLowerCase() as TemplateName);
 			else if (action === "Toggle segments") {
-				const current = runtime.getConfig().segments;
+				const current = runtime.getDisplaySettings().segmentLayout;
 				const optional: SegmentId[] = [
 					"brand",
 					"activity",
@@ -386,26 +385,27 @@ export async function openAtelierMenu(
 					"statuses",
 					"menu",
 				];
-				const labels = optional.map((id) => `${current.includes(id) ? "✓" : "○"} ${id}`);
+				const labels = optional.map(
+					(id) => `${current.find((entry) => entry.id === id)?.visible ? "✓" : "○"} ${id}`,
+				);
 				const selected = await ctx.ui.select("Toggle footer segment", labels);
 				const id = optional[labels.indexOf(selected ?? "")];
-				if (id)
-					actions.setSegments(
-						current.includes(id) ? current.filter((item) => item !== id) : [...current, id],
-					);
+				if (id) actions.toggleSegment(id);
 			} else if (action === "Reorder segments") {
-				const current = runtime.getConfig().segments;
-				const selected = await ctx.ui.select("Choose segment", current);
+				const current = runtime.getDisplaySettings().segmentLayout;
+				const labels = current.map((entry) => `${entry.visible ? "✓" : "○"} ${entry.id}`);
+				const selected = await ctx.ui.select("Choose segment", labels);
 				if (selected) {
 					const direction = await ctx.ui.select("Move segment", ["earlier", "later"]);
-					if (direction) actions.moveSegment(selected as SegmentId, direction as "earlier" | "later");
+					const id = current[labels.indexOf(selected)]?.id;
+					if (direction && id) actions.moveSegment(id, direction as "earlier" | "later");
 				}
 			} else if (action === "Density") {
 				const density = await ctx.ui.select("Footer density", ["comfortable", "compact"]);
 				if (density) actions.setDensity(density as AtelierConfig["density"]);
 			} else if (action === "Ornament") {
 				const ornament = await ctx.ui.select("Footer ornament", ["restrained", "none"]);
-				if (ornament) actions.setOrnament(ornament as AtelierConfig["ornament"]);
+				if (ornament) actions.setOrnament(ornament as Ornament);
 			} else if (action === "Save as user default") await actions.saveDisplayDefaults();
 		} else if (section === "session") {
 			const options = runtime.getConfig().showSessionActions

--- a/src/settings-workspace.ts
+++ b/src/settings-workspace.ts
@@ -1,0 +1,348 @@
+import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import {
+	applyDisplayTemplate,
+	derivePresetIdentity,
+	REQUIRED_SEGMENT_IDS,
+	reorderSegment,
+	toggleSegmentVisibility,
+} from "./display.js";
+import { renderFooterLine, type ThemeLike } from "./footer.js";
+import type {
+	AtelierConfig,
+	DisplayPatch,
+	DisplayProvenance,
+	DisplaySettings,
+	FooterState,
+	SegmentId,
+	SessionDisplayOverride,
+	TemplateName,
+} from "./types.js";
+
+export interface SettingsWorkspaceOptions {
+	getDisplaySettings(): DisplaySettings;
+	getDisplayProvenance(): DisplayProvenance;
+	getSessionDisplayOverride(): SessionDisplayOverride | undefined;
+	replaceSessionDisplayOverride(value: SessionDisplayOverride | undefined): void;
+	clearSessionDisplayOverride(): void;
+	persistUserDisplayPatch(patch: DisplayPatch): Promise<void>;
+	applySavedUserDisplayPatch(patch: DisplayPatch): void;
+	getRenderConfig(): AtelierConfig;
+	getPreviewState?(): FooterState;
+	theme: ThemeLike;
+	colorEnabled?: boolean;
+	requestWorkspaceRender(): void;
+	requestLiveRender(): void;
+	close(): void;
+	report?(message: string, kind: "info" | "warning" | "error"): void;
+}
+
+export interface SettingsWorkspace {
+	render(width: number): string[];
+	invalidate(): void;
+	handleInput(data: string): void;
+}
+
+const PRESETS: TemplateName[] = ["editorial", "minimal", "classic"];
+const DISPLAY_KEYS = ["preset", "density"] as const;
+type Row =
+	| { kind: "preset" | "density"; id: string }
+	| { kind: "segment"; id: SegmentId }
+	| { kind: "action"; id: "undo" | "revert" | "save" | "close" };
+
+const cloneDisplay = (value: DisplaySettings): DisplaySettings => ({
+	...value,
+	segmentLayout: value.segmentLayout.map((entry) => ({ ...entry })),
+});
+const cloneOverride = (value: SessionDisplayOverride | undefined): SessionDisplayOverride | undefined =>
+	value === undefined ? undefined : structuredClone(value);
+
+const representativeState: FooterState = {
+	activity: "working",
+	workingLabel: "CRAFTING",
+	modelId: "artisan-1",
+	provider: "atelier",
+	thinkingLevel: "high",
+	branch: "feat/settings",
+	dirty: true,
+	workspacePulse: {
+		status: "changed",
+		data: {
+			root: "/project",
+			relativeCwd: "",
+			branch: "feat/settings",
+			snapshot: {
+				trackedFiles: 2,
+				untrackedFiles: 1,
+				linesAdded: 24,
+				linesRemoved: 3,
+				binaryFiles: 0,
+				submodules: 0,
+				conflicts: 0,
+			},
+		},
+	},
+	metrics: {
+		usageAvailable: true,
+		costAvailable: true,
+		input: 12_400,
+		output: 3_200,
+		cacheRead: 8_100,
+		cacheWrite: 400,
+		cacheHitPercent: 72.4,
+		cost: 0.142,
+		subscription: false,
+		contextTokens: 32_000,
+		contextWindow: 128_000,
+		contextPercent: 25,
+		autoCompact: true,
+	},
+	performance: { ttftMs: 680, tokensPerSecond: 54 },
+	extensionStatuses: ["SYNC"],
+};
+
+function fit(text: string, width: number): string {
+	if (width <= 0) return "";
+	const clipped = truncateToWidth(text, width, "");
+	return `${clipped}${" ".repeat(Math.max(0, width - visibleWidth(clipped)))}`;
+}
+
+function panel(title: string, lines: string[], width: number, theme: ThemeLike, accent = false): string[] {
+	if (width < 4) return lines.map((line) => fit(line, width));
+	const inner = width - 2;
+	const color = accent ? "borderAccent" : "muted";
+	const edge = (text: string) => theme.fg(color, text);
+	const heading = ` ${title} `;
+	const rule = Math.max(0, inner - visibleWidth(heading));
+	return [
+		`${edge("┌")}${theme.bold(theme.fg(accent ? "accent" : "muted", heading))}${edge("─".repeat(rule))}${edge("┐")}`,
+		...lines.map((line) => `${edge("│")}${fit(line, inner)}${edge("│")}`),
+		`${edge("└")}${edge("─".repeat(inner))}${edge("┘")}`,
+	];
+}
+
+export function createSettingsWorkspace(options: SettingsWorkspaceOptions): SettingsWorkspace {
+	let display = cloneDisplay(options.getDisplaySettings());
+	let focus = 0;
+	let undo: SessionDisplayOverride | undefined;
+	let hasUndo = false;
+	let feedback = "Session changes are active immediately";
+	let saving = false;
+
+	const rows = (): Row[] => [
+		...DISPLAY_KEYS.map((id) => ({ kind: id, id }) as Row),
+		...display.segmentLayout.map((entry) => ({ kind: "segment", id: entry.id }) as Row),
+		{ kind: "action", id: "undo" },
+		{ kind: "action", id: "revert" },
+		{ kind: "action", id: "save" },
+		{ kind: "action", id: "close" },
+	];
+	const request = (live = false): void => {
+		options.requestWorkspaceRender();
+		if (live) options.requestLiveRender();
+	};
+	const tell = (message: string, kind: "info" | "warning" | "error" = "info"): void => {
+		feedback = message;
+		options.report?.(message, kind);
+	};
+	const refresh = (): void => {
+		display = cloneDisplay(options.getDisplaySettings());
+	};
+	const commitMutation = (next: DisplaySettings, message: string): void => {
+		undo = cloneOverride(options.getSessionDisplayOverride());
+		hasUndo = true;
+		const complete = cloneDisplay(next);
+		complete.preset = derivePresetIdentity(complete);
+		options.replaceSessionDisplayOverride(complete);
+		display = complete;
+		tell(message);
+		request(true);
+	};
+	const revert = (): void => {
+		undo = cloneOverride(options.getSessionDisplayOverride());
+		hasUndo = true;
+		options.clearSessionDisplayOverride();
+		refresh();
+		tell("Reverted to Effective lower-layer settings");
+		request(true);
+	};
+	const undoOnce = (): void => {
+		if (!hasUndo) {
+			tell("Nothing to undo", "warning");
+			request();
+			return;
+		}
+		options.replaceSessionDisplayOverride(cloneOverride(undo));
+		hasUndo = false;
+		undo = undefined;
+		refresh();
+		tell("Undid the last Display change");
+		request(true);
+	};
+	const save = async (): Promise<void> => {
+		if (saving) return;
+		saving = true;
+		request();
+		const patch: DisplayPatch = cloneDisplay(display);
+		try {
+			await options.persistUserDisplayPatch(patch);
+			options.applySavedUserDisplayPatch(patch);
+			refresh();
+			tell("Saved as User default");
+		} catch (error) {
+			tell(`Save failed: ${error instanceof Error ? error.message : String(error)}`, "error");
+		} finally {
+			saving = false;
+			request(true);
+		}
+	};
+	const activate = (): void => {
+		const row = rows()[focus];
+		if (!row) return;
+		if (row.kind === "preset") {
+			const current = PRESETS.indexOf(display.preset as TemplateName);
+			const next = PRESETS[(current + 1 + PRESETS.length) % PRESETS.length] ?? "editorial";
+			commitMutation(applyDisplayTemplate(next), `Applied ${next} preset`);
+		} else if (row.kind === "density") {
+			commitMutation(
+				{ ...cloneDisplay(display), density: display.density === "compact" ? "comfortable" : "compact" },
+				"Changed density",
+			);
+		} else if (row.kind === "segment") {
+			if ((REQUIRED_SEGMENT_IDS as readonly SegmentId[]).includes(row.id)) {
+				tell(`${row.id} is required; use Shift+Up/Down to reorder`, "warning");
+				request();
+				return;
+			}
+			commitMutation(
+				{ ...cloneDisplay(display), segmentLayout: toggleSegmentVisibility(display.segmentLayout, row.id) },
+				`Toggled ${row.id}`,
+			);
+		} else if (row.id === "undo") undoOnce();
+		else if (row.id === "revert") revert();
+		else if (row.id === "save") void save();
+		else options.close();
+	};
+	const move = (direction: "earlier" | "later"): void => {
+		const row = rows()[focus];
+		if (!row || row.kind !== "segment") {
+			tell("Select a Segment to reorder", "warning");
+			request();
+			return;
+		}
+		const index = display.segmentLayout.findIndex((entry) => entry.id === row.id);
+		const target = direction === "earlier" ? index - 1 : index + 1;
+		if (target < 0 || target >= display.segmentLayout.length) {
+			tell(`${row.id} is already at the ${direction === "earlier" ? "start" : "end"}`, "warning");
+			request();
+			return;
+		}
+		commitMutation(
+			{ ...cloneDisplay(display), segmentLayout: reorderSegment(display.segmentLayout, row.id, direction) },
+			`Moved ${row.id} ${direction}`,
+		);
+		focus = 2 + target;
+	};
+
+	return {
+		invalidate() {},
+		handleInput(data: string) {
+			if (matchesKey(data, "up")) {
+				focus = Math.max(0, focus - 1);
+				request();
+			} else if (matchesKey(data, "down")) {
+				focus = Math.min(rows().length - 1, focus + 1);
+				request();
+			} else if (matchesKey(data, "shift+up")) move("earlier");
+			else if (matchesKey(data, "shift+down")) move("later");
+			else if (matchesKey(data, "enter") || data === " ") activate();
+			else if (matchesKey(data, "escape")) options.close();
+			else if (data.toLowerCase() === "u") undoOnce();
+			else if (data.toLowerCase() === "r") revert();
+			else if (data.toLowerCase() === "s") void save();
+		},
+		render(width: number): string[] {
+			if (width <= 0) return [];
+			const outerInner = Math.max(0, width - 2);
+			const provenance = options.getDisplayProvenance();
+			const allRows = rows();
+			const marker = (index: number) => (focus === index ? options.theme.fg("accent", "›") : " ");
+			const displayLines = [
+				`${marker(0)} Preset     ${display.preset.padEnd(12)} ${provenance.preset}`,
+				`${marker(1)} Density    ${display.density.padEnd(12)} ${provenance.density}`,
+				"",
+				`${marker(11)} Undo       ${hasUndo ? "available" : "—"}`,
+				`${marker(12)} Revert     Effective baseline`,
+				`${marker(13)} Save       ${saving ? "saving…" : "User default"}`,
+				`${marker(14)} Close      keep Session changes`,
+			];
+			const segmentLines = display.segmentLayout.map((entry, index) => {
+				const required = (REQUIRED_SEGMENT_IDS as readonly SegmentId[]).includes(entry.id);
+				const status = required ? "required" : entry.visible ? "shown" : "hidden";
+				return `${marker(index + 2)} ${entry.id.padEnd(12)} ${status.padEnd(8)} ${provenance.visibility[entry.id]}`;
+			});
+			const previewConfig = { ...options.getRenderConfig(), ...cloneDisplay(display) };
+			const previewWidth = Math.max(1, outerInner - 4);
+			const preview = panel(
+				"Representative Status Rail",
+				[
+					renderFooterLine(
+						options.getPreviewState?.() ?? representativeState,
+						previewConfig,
+						options.theme,
+						previewWidth,
+						options.colorEnabled ?? true,
+					),
+				],
+				outerInner,
+				options.theme,
+				true,
+			);
+			let editing: string[];
+			if (outerInner >= 76) {
+				const leftWidth = Math.floor((outerInner - 1) * 0.45);
+				const rightWidth = outerInner - 1 - leftWidth;
+				const height = Math.max(displayLines.length, segmentLines.length);
+				const left = panel(
+					"Display",
+					[...displayLines, ...Array(Math.max(0, height - displayLines.length)).fill("")],
+					leftWidth,
+					options.theme,
+				);
+				const right = panel(
+					"Segments",
+					[...segmentLines, ...Array(Math.max(0, height - segmentLines.length)).fill("")],
+					rightWidth,
+					options.theme,
+				);
+				editing = left.map((line, index) => `${line} ${right[index] ?? fit("", rightWidth)}`);
+			} else {
+				editing = [
+					...panel("Display", displayLines, outerInner, options.theme),
+					...panel("Segments", segmentLines, outerInner, options.theme),
+				];
+			}
+			const selected = allRows[focus];
+			const selectedRequired =
+				selected?.kind === "segment" && (REQUIRED_SEGMENT_IDS as readonly SegmentId[]).includes(selected.id);
+			const guidance =
+				selected?.kind === "segment"
+					? selectedRequired
+						? "Required · Shift+↑/↓ Reorder · U Undo · R Revert · S Save · Esc Close"
+						: "Enter/Space Toggle · Shift+↑/↓ Reorder · U Undo · R Revert · S Save · Esc Close"
+					: "↑/↓ Select · Enter/Space Change · U Undo · R Revert · S Save · Esc Close";
+			const content = [
+				fit(options.theme.bold("Display Settings") + "  Session overrides → Effective preview", outerInner),
+				...preview,
+				...editing,
+				fit(feedback, outerInner),
+				fit(guidance, outerInner),
+			];
+			const border = (text: string) => options.theme.fg("borderAccent", text);
+			return [
+				border(`╭${"─".repeat(outerInner)}╮`),
+				...content.map((line) => `${border("│")}${fit(line, outerInner)}${border("│")}`),
+				border(`╰${"─".repeat(outerInner)}╯`),
+			].map((line) => truncateToWidth(line, width, ""));
+		},
+	};
+}

--- a/src/settings-workspace.ts
+++ b/src/settings-workspace.ts
@@ -270,18 +270,21 @@ export function createSettingsWorkspace(options: SettingsWorkspaceOptions): Sett
 			const presetRow: Row = { kind: "preset", id: "preset" };
 			const densityRow: Row = { kind: "density", id: "density" };
 			const actionRow = (id: Extract<Row, { kind: "action" }>["id"]): Row => ({ kind: "action", id });
+			const actionLine = (id: Extract<Row, { kind: "action" }>["id"], label: string, hint: string) =>
+				`${marker(actionRow(id))} ${label.padEnd(16)}${hint}`;
 			const sessionChanged = options.getSessionDisplayOverride() !== undefined;
 			const status = saving ? "saving…" : sessionChanged ? "session changed" : "effective";
 			const displayLines = [
 				`${marker(presetRow)} Preset       ${display.preset.padEnd(13)} ${provenance.preset}`,
 				`${marker(densityRow)} Density      ${display.density.padEnd(13)} ${provenance.density}`,
 				"",
-				`${marker(actionRow("save"))} Save default ${saving ? "saving…" : "S"}`,
-				`${marker(actionRow("revert"))} Revert      R`,
-				`${marker(actionRow("undo"))} Undo        ${hasUndo ? "U" : "—"}`,
+				actionLine("save", "Save default", saving ? "saving…" : "S"),
+				actionLine("revert", "Revert session", "R"),
+				actionLine("undo", "Undo", hasUndo ? "U" : "—"),
 			];
 			const segmentLines = [
-				options.theme.fg("muted", `  ● shown · ○ hidden · ◆ required · order:${provenance.order}`),
+				options.theme.fg("muted", `  ● shown   ○ hidden   ◆ required   order ${provenance.order}`),
+				"",
 				...display.segmentLayout.map((entry, index) => {
 					const required = (REQUIRED_SEGMENT_IDS as readonly SegmentId[]).includes(entry.id);
 					const state = required ? "◆" : entry.visible ? "●" : "○";
@@ -349,7 +352,8 @@ export function createSettingsWorkspace(options: SettingsWorkspaceOptions): Sett
 				...preview,
 				"",
 				...editing,
-				...(feedback ? ["", fit(feedback, outerInner)] : []),
+				"",
+				...(feedback ? [fit(feedback, outerInner)] : []),
 				fit(guidance, outerInner),
 			];
 			const border = (text: string) => options.theme.fg("borderAccent", text);

--- a/src/settings-workspace.ts
+++ b/src/settings-workspace.ts
@@ -136,6 +136,8 @@ export function createSettingsWorkspace(options: SettingsWorkspaceOptions): Sett
 		{ kind: "action", id: "save" },
 		{ kind: "action", id: "close" },
 	];
+	const rowIndex = (target: Row, allRows = rows()): number =>
+		allRows.findIndex((row) => row.kind === target.kind && row.id === target.id);
 	const request = (live = false): void => {
 		options.requestWorkspaceRender();
 		if (live) options.requestLiveRender();
@@ -240,7 +242,7 @@ export function createSettingsWorkspace(options: SettingsWorkspaceOptions): Sett
 			{ ...cloneDisplay(display), segmentLayout: reorderSegment(display.segmentLayout, row.id, direction) },
 			`Moved ${row.id} ${direction}`,
 		);
-		focus = 2 + target;
+		focus = rowIndex(row);
 	};
 
 	return {
@@ -265,38 +267,41 @@ export function createSettingsWorkspace(options: SettingsWorkspaceOptions): Sett
 			const outerInner = Math.max(0, width - 2);
 			const provenance = options.getDisplayProvenance();
 			const allRows = rows();
-			const marker = (index: number) => (focus === index ? options.theme.fg("accent", "›") : " ");
+			const marker = (row: Row) => (focus === rowIndex(row, allRows) ? options.theme.fg("accent", "›") : " ");
+			const presetRow: Row = { kind: "preset", id: "preset" };
+			const densityRow: Row = { kind: "density", id: "density" };
+			const actionRow = (id: Extract<Row, { kind: "action" }>["id"]): Row => ({ kind: "action", id });
 			const displayLines = [
-				`${marker(0)} Preset     ${display.preset.padEnd(12)} ${provenance.preset}`,
-				`${marker(1)} Density    ${display.density.padEnd(12)} ${provenance.density}`,
+				`${marker(presetRow)} Preset     ${display.preset.padEnd(12)} ${provenance.preset}`,
+				`${marker(densityRow)} Density    ${display.density.padEnd(12)} ${provenance.density}`,
+				`  Order      ${provenance.order.padEnd(12)} ${display.segmentLayout.map((entry) => entry.id).join(" › ")}`,
 				"",
-				`${marker(11)} Undo       ${hasUndo ? "available" : "—"}`,
-				`${marker(12)} Revert     Effective baseline`,
-				`${marker(13)} Save       ${saving ? "saving…" : "User default"}`,
-				`${marker(14)} Close      keep Session changes`,
+				`${marker(actionRow("undo"))} Undo       ${hasUndo ? "available" : "—"}`,
+				`${marker(actionRow("revert"))} Revert     Effective baseline`,
+				`${marker(actionRow("save"))} Save       ${saving ? "saving…" : "User default"}`,
+				`${marker(actionRow("close"))} Close      keep Session changes`,
 			];
-			const segmentLines = display.segmentLayout.map((entry, index) => {
+			const segmentLines = display.segmentLayout.map((entry) => {
 				const required = (REQUIRED_SEGMENT_IDS as readonly SegmentId[]).includes(entry.id);
 				const status = required ? "required" : entry.visible ? "shown" : "hidden";
-				return `${marker(index + 2)} ${entry.id.padEnd(12)} ${status.padEnd(8)} ${provenance.visibility[entry.id]}`;
+				return `${marker({ kind: "segment", id: entry.id })} ${entry.id.padEnd(12)} ${status.padEnd(8)} ${provenance.visibility[entry.id]}`;
 			});
 			const previewConfig = { ...options.getRenderConfig(), ...cloneDisplay(display) };
-			const previewWidth = Math.max(1, outerInner - 4);
-			const preview = panel(
-				"Representative Status Rail",
-				[
-					renderFooterLine(
-						options.getPreviewState?.() ?? representativeState,
-						previewConfig,
-						options.theme,
-						previewWidth,
-						options.colorEnabled ?? true,
-					),
-				],
-				outerInner,
-				options.theme,
-				true,
-			);
+			const previewState = options.getPreviewState?.() ?? representativeState;
+			const previewLineWidth = Math.max(1, outerInner - 16);
+			const previewLines = display.segmentLayout
+				.filter((entry) => entry.visible)
+				.map(
+					(entry) =>
+						`${entry.id.padEnd(12)} ${renderFooterLine(
+							previewState,
+							{ ...previewConfig, segmentLayout: [{ ...entry }] },
+							options.theme,
+							previewLineWidth,
+							options.colorEnabled ?? true,
+						)}`,
+				);
+			const preview = panel("Representative Status Rail", previewLines, outerInner, options.theme, true);
 			let editing: string[];
 			if (outerInner >= 76) {
 				const leftWidth = Math.floor((outerInner - 1) * 0.45);

--- a/src/settings-workspace.ts
+++ b/src/settings-workspace.ts
@@ -45,9 +45,10 @@ export interface SettingsWorkspace {
 const PRESETS: TemplateName[] = ["editorial", "minimal", "classic"];
 const DISPLAY_KEYS = ["preset", "density"] as const;
 type Row =
-	| { kind: "preset" | "density"; id: string }
+	| { kind: "preset"; id: "preset" }
+	| { kind: "density"; id: "density" }
 	| { kind: "segment"; id: SegmentId }
-	| { kind: "action"; id: "undo" | "revert" | "save" | "close" };
+	| { kind: "action"; id: "save" | "revert" | "undo" };
 
 const cloneDisplay = (value: DisplaySettings): DisplaySettings => ({
 	...value,
@@ -125,16 +126,15 @@ export function createSettingsWorkspace(options: SettingsWorkspaceOptions): Sett
 	let focus = 0;
 	let undo: SessionDisplayOverride | undefined;
 	let hasUndo = false;
-	let feedback = "Session changes are active immediately";
+	let feedback = "";
 	let saving = false;
 
 	const rows = (): Row[] => [
 		...DISPLAY_KEYS.map((id) => ({ kind: id, id }) as Row),
 		...display.segmentLayout.map((entry) => ({ kind: "segment", id: entry.id }) as Row),
-		{ kind: "action", id: "undo" },
-		{ kind: "action", id: "revert" },
 		{ kind: "action", id: "save" },
-		{ kind: "action", id: "close" },
+		{ kind: "action", id: "revert" },
+		{ kind: "action", id: "undo" },
 	];
 	const rowIndex = (target: Row, allRows = rows()): number =>
 		allRows.findIndex((row) => row.kind === target.kind && row.id === target.id);
@@ -219,10 +219,9 @@ export function createSettingsWorkspace(options: SettingsWorkspaceOptions): Sett
 				{ ...cloneDisplay(display), segmentLayout: toggleSegmentVisibility(display.segmentLayout, row.id) },
 				`Toggled ${row.id}`,
 			);
-		} else if (row.id === "undo") undoOnce();
+		} else if (row.id === "save") void save();
 		else if (row.id === "revert") revert();
-		else if (row.id === "save") void save();
-		else options.close();
+		else undoOnce();
 	};
 	const move = (direction: "earlier" | "later"): void => {
 		const row = rows()[focus];
@@ -271,41 +270,39 @@ export function createSettingsWorkspace(options: SettingsWorkspaceOptions): Sett
 			const presetRow: Row = { kind: "preset", id: "preset" };
 			const densityRow: Row = { kind: "density", id: "density" };
 			const actionRow = (id: Extract<Row, { kind: "action" }>["id"]): Row => ({ kind: "action", id });
+			const sessionChanged = options.getSessionDisplayOverride() !== undefined;
+			const status = saving ? "saving…" : sessionChanged ? "session changed" : "effective";
 			const displayLines = [
-				`${marker(presetRow)} Preset     ${display.preset.padEnd(12)} ${provenance.preset}`,
-				`${marker(densityRow)} Density    ${display.density.padEnd(12)} ${provenance.density}`,
-				`  Order      ${provenance.order.padEnd(12)} ${display.segmentLayout.map((entry) => entry.id).join(" › ")}`,
+				`${marker(presetRow)} Preset       ${display.preset.padEnd(13)} ${provenance.preset}`,
+				`${marker(densityRow)} Density      ${display.density.padEnd(13)} ${provenance.density}`,
 				"",
-				`${marker(actionRow("undo"))} Undo       ${hasUndo ? "available" : "—"}`,
-				`${marker(actionRow("revert"))} Revert     Effective baseline`,
-				`${marker(actionRow("save"))} Save       ${saving ? "saving…" : "User default"}`,
-				`${marker(actionRow("close"))} Close      keep Session changes`,
+				`${marker(actionRow("save"))} Save default ${saving ? "saving…" : "S"}`,
+				`${marker(actionRow("revert"))} Revert      R`,
+				`${marker(actionRow("undo"))} Undo        ${hasUndo ? "U" : "—"}`,
 			];
-			const segmentLines = display.segmentLayout.map((entry) => {
-				const required = (REQUIRED_SEGMENT_IDS as readonly SegmentId[]).includes(entry.id);
-				const status = required ? "required" : entry.visible ? "shown" : "hidden";
-				return `${marker({ kind: "segment", id: entry.id })} ${entry.id.padEnd(12)} ${status.padEnd(8)} ${provenance.visibility[entry.id]}`;
-			});
+			const segmentLines = [
+				options.theme.fg("muted", `  ● shown · ○ hidden · ◆ required · order:${provenance.order}`),
+				...display.segmentLayout.map((entry, index) => {
+					const required = (REQUIRED_SEGMENT_IDS as readonly SegmentId[]).includes(entry.id);
+					const state = required ? "◆" : entry.visible ? "●" : "○";
+					const suffix = required ? "  required" : "";
+					return `${marker({ kind: "segment", id: entry.id })} ${String(index + 1).padStart(2)}  ${state} ${entry.id.padEnd(12)}${suffix}`;
+				}),
+			];
 			const previewConfig = { ...options.getRenderConfig(), ...cloneDisplay(display) };
 			const previewState = options.getPreviewState?.() ?? representativeState;
-			const previewLineWidth = Math.max(1, outerInner - 16);
-			const previewLines = display.segmentLayout
-				.filter((entry) => entry.visible)
-				.map(
-					(entry) =>
-						`${entry.id.padEnd(12)} ${renderFooterLine(
-							previewState,
-							{ ...previewConfig, segmentLayout: [{ ...entry }] },
-							options.theme,
-							previewLineWidth,
-							options.colorEnabled ?? true,
-						)}`,
-				);
-			const preview = panel("Representative Status Rail", previewLines, outerInner, options.theme, true);
+			const previewLine = renderFooterLine(
+				previewState,
+				previewConfig,
+				options.theme,
+				Math.max(1, outerInner - 6),
+				options.colorEnabled ?? true,
+			);
+			const preview = panel("Preview", [`  ${previewLine}`], outerInner, options.theme, true);
 			let editing: string[];
-			if (outerInner >= 76) {
-				const leftWidth = Math.floor((outerInner - 1) * 0.45);
-				const rightWidth = outerInner - 1 - leftWidth;
+			if (outerInner >= 72) {
+				const leftWidth = Math.max(28, Math.floor((outerInner - 2) * 0.4));
+				const rightWidth = outerInner - leftWidth - 2;
 				const height = Math.max(displayLines.length, segmentLines.length);
 				const left = panel(
 					"Display",
@@ -314,32 +311,45 @@ export function createSettingsWorkspace(options: SettingsWorkspaceOptions): Sett
 					options.theme,
 				);
 				const right = panel(
-					"Segments",
+					"Segment Editor",
 					[...segmentLines, ...Array(Math.max(0, height - segmentLines.length)).fill("")],
 					rightWidth,
 					options.theme,
 				);
-				editing = left.map((line, index) => `${line} ${right[index] ?? fit("", rightWidth)}`);
+				editing = left.map((line, index) => `${line}  ${right[index] ?? fit("", rightWidth)}`);
 			} else {
 				editing = [
 					...panel("Display", displayLines, outerInner, options.theme),
-					...panel("Segments", segmentLines, outerInner, options.theme),
+					"",
+					...panel("Segment Editor", segmentLines, outerInner, options.theme),
 				];
 			}
 			const selected = allRows[focus];
-			const selectedRequired =
-				selected?.kind === "segment" && (REQUIRED_SEGMENT_IDS as readonly SegmentId[]).includes(selected.id);
-			const guidance =
-				selected?.kind === "segment"
-					? selectedRequired
-						? "Required · Shift+↑/↓ Reorder · U Undo · R Revert · S Save · Esc Close"
-						: "Enter/Space Toggle · Shift+↑/↓ Reorder · U Undo · R Revert · S Save · Esc Close"
-					: "↑/↓ Select · Enter/Space Change · U Undo · R Revert · S Save · Esc Close";
+			let guidance = "↑/↓ Select · Enter Change · S Save · Esc Close";
+			if (selected?.kind === "segment") {
+				const required = (REQUIRED_SEGMENT_IDS as readonly SegmentId[]).includes(selected.id);
+				const visibility = required
+					? "required"
+					: display.segmentLayout.find((entry) => entry.id === selected.id)?.visible
+						? "shown"
+						: "hidden";
+				guidance = `${selected.id} · ${visibility} · source:${provenance.visibility[selected.id]} · order:${provenance.order} · ${required ? "Shift+↑/↓ Reorder" : "Enter Toggle · Shift+↑/↓ Reorder"}`;
+			} else if (selected?.kind === "preset" || selected?.kind === "density") {
+				guidance = `${selected.id} · source:${provenance[selected.id]} · Enter Change · U Undo`;
+			} else if (selected?.kind === "action") {
+				guidance = `${selected.id} · Enter or ${selected.id === "save" ? "S" : selected.id === "revert" ? "R" : "U"}`;
+			}
 			const content = [
-				fit(options.theme.bold("Display Settings") + "  Session overrides → Effective preview", outerInner),
+				fit(
+					`${options.theme.bold("DISPLAY SETTINGS")}  ${options.theme.fg(sessionChanged ? "warning" : "success", status)}`,
+					outerInner,
+				),
+				fit(options.theme.fg("muted", "↑/↓ Select · Enter Change · S Save · Esc Close"), outerInner),
+				"",
 				...preview,
+				"",
 				...editing,
-				fit(feedback, outerInner),
+				...(feedback ? ["", fit(feedback, outerInner)] : []),
 				fit(guidance, outerInner),
 			];
 			const border = (text: string) => options.theme.fg("borderAccent", text);

--- a/src/state.ts
+++ b/src/state.ts
@@ -20,6 +20,14 @@ import {
 } from "./workspace-pulse.js";
 
 const WORKSPACE_REFRESH_DEBOUNCE_MS = 250;
+const SESSION_DISPLAY_OVERRIDE_KEYS = [
+	"preset",
+	"density",
+	"segmentLayout",
+	"segments",
+	"ornament",
+	"showExtensionStatuses",
+] as const;
 
 export interface RuntimeDependencies {
 	pi: ExtensionAPI;
@@ -101,14 +109,7 @@ export class AtelierRuntime {
 		const session = this.#displayLayers.session;
 		if (!session) return undefined;
 		const result: SessionDisplayOverride = {};
-		for (const key of [
-			"preset",
-			"density",
-			"segmentLayout",
-			"segments",
-			"ornament",
-			"showExtensionStatuses",
-		] as const) {
+		for (const key of SESSION_DISPLAY_OVERRIDE_KEYS) {
 			if (!(key in session)) continue;
 			const value = session[key];
 			(result as Record<string, unknown>)[key] =
@@ -123,15 +124,7 @@ export class AtelierRuntime {
 
 	replaceSessionDisplayOverride(override: SessionDisplayOverride | undefined): void {
 		const session = { ...this.#displayLayers.session };
-		for (const key of [
-			"preset",
-			"density",
-			"segmentLayout",
-			"segments",
-			"ornament",
-			"showExtensionStatuses",
-		] as const)
-			delete session[key];
+		for (const key of SESSION_DISPLAY_OVERRIDE_KEYS) delete session[key];
 		if (override) Object.assign(session, structuredClone(override));
 		const { session: _oldSession, ...lower } = this.#displayLayers;
 		this.#displayLayers = Object.keys(session).length > 0 ? { ...lower, session } : lower;

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,8 +1,17 @@
 import { isDeepStrictEqual } from "node:util";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { selectWorkingPhrase } from "./activity.js";
+import { resolveDisplayLayers } from "./config.js";
 import { aggregateMetrics, type UsageMessage } from "./metrics.js";
-import type { ActivityState, AtelierConfig, AtelierState } from "./types.js";
+import type {
+	ActivityState,
+	AtelierConfig,
+	AtelierState,
+	DisplayLayerState,
+	DisplayPatch,
+	DisplayProvenance,
+	DisplaySettings,
+} from "./types.js";
 import {
 	inspectWorkspacePulse,
 	type WorkspacePulseData,
@@ -15,6 +24,8 @@ export interface RuntimeDependencies {
 	pi: ExtensionAPI;
 	ctx: ExtensionContext;
 	config: AtelierConfig;
+	displayLayers?: DisplayLayerState;
+	displayProvenance?: DisplayProvenance;
 	autoCompact: boolean | null;
 	random?: () => number;
 	requestRender(): void;
@@ -29,6 +40,8 @@ export class AtelierRuntime {
 	readonly #requestRender: () => void;
 	readonly #inspectWorkspace: () => Promise<WorkspacePulseInspection>;
 	#config: AtelierConfig;
+	#displayLayers: DisplayLayerState;
+	#displayProvenance: DisplayProvenance;
 	#disposed = false;
 	#workspaceRefreshGeneration = 0;
 	#workspaceRefreshTimer: ReturnType<typeof setTimeout> | undefined;
@@ -39,6 +52,9 @@ export class AtelierRuntime {
 		this.#pi = dependencies.pi;
 		this.#ctx = dependencies.ctx;
 		this.#config = dependencies.config;
+		this.#displayLayers = dependencies.displayLayers ?? {};
+		this.#displayProvenance =
+			dependencies.displayProvenance ?? resolveDisplayLayers(this.#displayLayers).provenance;
 		this.#autoCompact = dependencies.autoCompact;
 		this.#random = dependencies.random ?? Math.random;
 		this.#requestRender = dependencies.requestRender;
@@ -66,6 +82,34 @@ export class AtelierRuntime {
 
 	getConfig(): AtelierConfig {
 		return this.#config;
+	}
+
+	getDisplaySettings(): DisplaySettings {
+		return {
+			preset: this.#config.preset,
+			density: this.#config.density,
+			segmentLayout: this.#config.segmentLayout.map((entry) => ({ ...entry })),
+		};
+	}
+
+	getDisplayProvenance(): DisplayProvenance {
+		return { ...this.#displayProvenance, visibility: { ...this.#displayProvenance.visibility } };
+	}
+
+	setSessionDisplayPatch(patch: DisplayPatch | undefined): void {
+		if (patch) {
+			this.#displayLayers = {
+				...this.#displayLayers,
+				session: { ...this.#displayLayers.session, ...patch },
+			};
+		} else {
+			const { session: _session, ...lowerLayers } = this.#displayLayers;
+			this.#displayLayers = lowerLayers;
+		}
+		const resolved = resolveDisplayLayers(this.#displayLayers);
+		this.#displayProvenance = resolved.provenance;
+		this.#config = { ...this.#config, ...resolved.display };
+		this.#invalidate();
 	}
 
 	setConfig(config: AtelierConfig): void {

--- a/src/state.ts
+++ b/src/state.ts
@@ -11,6 +11,7 @@ import type {
 	DisplayPatch,
 	DisplayProvenance,
 	DisplaySettings,
+	SessionDisplayOverride,
 } from "./types.js";
 import {
 	inspectWorkspacePulse,
@@ -96,16 +97,84 @@ export class AtelierRuntime {
 		return { ...this.#displayProvenance, visibility: { ...this.#displayProvenance.visibility } };
 	}
 
-	setSessionDisplayPatch(patch: DisplayPatch | undefined): void {
-		if (patch) {
-			this.#displayLayers = {
-				...this.#displayLayers,
-				session: { ...this.#displayLayers.session, ...patch },
-			};
-		} else {
-			const { session: _session, ...lowerLayers } = this.#displayLayers;
-			this.#displayLayers = lowerLayers;
+	getSessionDisplayOverride(): SessionDisplayOverride | undefined {
+		const session = this.#displayLayers.session;
+		if (!session) return undefined;
+		const result: SessionDisplayOverride = {};
+		for (const key of [
+			"preset",
+			"density",
+			"segmentLayout",
+			"segments",
+			"ornament",
+			"showExtensionStatuses",
+		] as const) {
+			if (!(key in session)) continue;
+			const value = session[key];
+			(result as Record<string, unknown>)[key] =
+				key === "segmentLayout" && Array.isArray(value)
+					? value.map((entry) => (typeof entry === "object" && entry !== null ? { ...entry } : entry))
+					: Array.isArray(value)
+						? [...value]
+						: value;
 		}
+		return Object.keys(result).length > 0 ? result : undefined;
+	}
+
+	replaceSessionDisplayOverride(override: SessionDisplayOverride | undefined): void {
+		const session = { ...this.#displayLayers.session };
+		for (const key of [
+			"preset",
+			"density",
+			"segmentLayout",
+			"segments",
+			"ornament",
+			"showExtensionStatuses",
+		] as const)
+			delete session[key];
+		if (override) Object.assign(session, structuredClone(override));
+		const { session: _oldSession, ...lower } = this.#displayLayers;
+		this.#displayLayers = Object.keys(session).length > 0 ? { ...lower, session } : lower;
+		this.#resolveDisplay();
+	}
+
+	clearSessionDisplayOverride(): void {
+		this.replaceSessionDisplayOverride(undefined);
+	}
+
+	setSessionDisplayPatch(patch: DisplayPatch | undefined): void {
+		if (!patch) {
+			this.clearSessionDisplayOverride();
+			return;
+		}
+		this.replaceSessionDisplayOverride({ ...this.getSessionDisplayOverride(), ...structuredClone(patch) });
+	}
+
+	/** Applies a successfully persisted User patch, then safely drops redundant Session fields. */
+	applySavedUserDisplayPatch(patch: DisplayPatch, canonicalizeSession = true): void {
+		this.#displayLayers = {
+			...this.#displayLayers,
+			user: { ...this.#displayLayers.user, ...structuredClone(patch) },
+		};
+		if (canonicalizeSession) {
+			const target = resolveDisplayLayers(this.#displayLayers).display;
+			let session = { ...this.#displayLayers.session };
+			for (const key of ["preset", "density", "segmentLayout"] as const) {
+				if (!(key in session)) continue;
+				const candidate = { ...session };
+				delete candidate[key];
+				const { session: _oldSession, ...lower } = this.#displayLayers;
+				const layers: DisplayLayerState =
+					Object.keys(candidate).length > 0 ? { ...lower, session: candidate } : lower;
+				if (isDeepStrictEqual(resolveDisplayLayers(layers).display, target)) session = candidate;
+			}
+			const { session: _oldSession, ...lower } = this.#displayLayers;
+			this.#displayLayers = Object.keys(session).length > 0 ? { ...lower, session } : lower;
+		}
+		this.#resolveDisplay();
+	}
+
+	#resolveDisplay(): void {
 		const resolved = resolveDisplayLayers(this.#displayLayers);
 		this.#displayProvenance = resolved.provenance;
 		this.#config = { ...this.#config, ...resolved.display };

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,13 @@ export interface DisplayLayerState {
 	session?: Record<string, unknown>;
 }
 
+/** A detached copy of the raw Session Display layer. */
+export type SessionDisplayOverride = DisplayPatch & {
+	segments?: unknown;
+	ornament?: unknown;
+	showExtensionStatuses?: unknown;
+};
+
 export interface ResponsePerformance {
 	ttftMs: number;
 	tokensPerSecond?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { WorkspacePulseData } from "./workspace-pulse.js";
 
-export type PresetName = "editorial" | "minimal" | "classic";
+export type TemplateName = "editorial" | "minimal" | "classic";
+export type PresetName = TemplateName | "custom";
 export type ActivityState = "ready" | "working" | "warning" | "error";
 export type SegmentId =
 	| "brand"
@@ -13,7 +14,40 @@ export type SegmentId =
 	| "statuses"
 	| "menu";
 export type Density = "comfortable" | "compact";
+/** Legacy menu vocabulary. Ornament is translated to Brand visibility. */
 export type Ornament = "none" | "restrained";
+export type ConfigurationSource = "product" | "user" | "project" | "session";
+
+export interface SegmentLayoutEntry {
+	id: SegmentId;
+	visible: boolean;
+}
+export type SegmentLayout = SegmentLayoutEntry[];
+
+export interface DisplaySettings {
+	preset: PresetName;
+	density: Density;
+	segmentLayout: SegmentLayout;
+}
+
+export interface DisplayPatch {
+	preset?: PresetName;
+	density?: Density;
+	segmentLayout?: SegmentLayout;
+}
+
+export interface DisplayProvenance {
+	preset: ConfigurationSource;
+	density: ConfigurationSource;
+	order: ConfigurationSource;
+	visibility: Record<SegmentId, ConfigurationSource>;
+}
+
+export interface DisplayLayerState {
+	user?: Record<string, unknown>;
+	project?: Record<string, unknown>;
+	session?: Record<string, unknown>;
+}
 
 export interface ResponsePerformance {
 	ttftMs: number;
@@ -26,16 +60,11 @@ export interface DisplayValue {
 	available: boolean;
 }
 
-export interface AtelierConfig {
-	preset: PresetName;
+export interface AtelierConfig extends DisplaySettings {
 	shortcut: string;
-	segments: SegmentId[];
-	density: Density;
-	ornament: Ornament;
 	contextWarning: number;
 	contextDanger: number;
 	currencyDecimals: number;
-	showExtensionStatuses: boolean;
 	showSessionActions: boolean;
 	showSidebarToolNames: boolean;
 	completionNotifications: boolean;
@@ -83,13 +112,21 @@ export interface FooterState extends AtelierState {
 export const DEFAULT_CONFIG: AtelierConfig = {
 	preset: "editorial",
 	shortcut: "alt+a",
-	segments: ["brand", "activity", "metrics", "context", "model", "git", "statuses", "menu"],
+	segmentLayout: [
+		{ id: "brand", visible: false },
+		{ id: "activity", visible: true },
+		{ id: "metrics", visible: true },
+		{ id: "performance", visible: false },
+		{ id: "context", visible: true },
+		{ id: "model", visible: true },
+		{ id: "git", visible: true },
+		{ id: "statuses", visible: true },
+		{ id: "menu", visible: true },
+	],
 	density: "comfortable",
-	ornament: "none",
 	contextWarning: 70,
 	contextDanger: 90,
 	currencyDecimals: 3,
-	showExtensionStatuses: true,
 	showSessionActions: true,
 	showSidebarToolNames: false,
 	completionNotifications: true,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -34,6 +34,23 @@ describe("configuration", () => {
 		expect(DEFAULT_CONFIG.completionNotifications).toBe(true);
 	});
 
+	it("applies named templates atomically before same-layer deviations", () => {
+		const named = validateConfig({ preset: "minimal" });
+		expect(named.config).toMatchObject({ preset: "minimal", density: "compact" });
+		expect(named.config.segmentLayout).toEqual(DISPLAY_TEMPLATES.minimal.segmentLayout);
+
+		const deviated = validateConfig({ preset: "minimal", density: "comfortable" });
+		expect(deviated.config.preset).toBe("custom");
+		expect(deviated.config.segmentLayout).toEqual(DISPLAY_TEMPLATES.minimal.segmentLayout);
+	});
+
+	it("preserves the public validateConfig base Display values", () => {
+		const base = { ...DEFAULT_CONFIG, ...DISPLAY_TEMPLATES.minimal };
+		const result = validateConfig({ shortcut: "ctrl+x" }, base);
+		expect(result.config).toMatchObject({ preset: "minimal", density: "compact", shortcut: "ctrl+x" });
+		expect(result.config.segmentLayout).toEqual(DISPLAY_TEMPLATES.minimal.segmentLayout);
+	});
+
 	it("merges user, trusted project, then session with actionable provenance", async () => {
 		await writeJson(userPath, { density: "compact" });
 		await writeJson(projectPath, {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -3,12 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import { loadConfig, saveUserConfig, saveUserConfigPatch, validateConfig } from "../src/config.js";
+import { DISPLAY_TEMPLATES, PRODUCT_SEGMENT_ORDER } from "../src/display.js";
 import { DEFAULT_CONFIG } from "../src/types.js";
 
 let root: string;
 let userPath: string;
 let projectPath: string;
-
 const writeJson = (path: string, value: unknown) => writeFile(path, JSON.stringify(value), "utf8");
 
 beforeEach(async () => {
@@ -17,28 +17,43 @@ beforeEach(async () => {
 	projectPath = join(root, "project.json");
 });
 
+const visibility = (layout: typeof DEFAULT_CONFIG.segmentLayout, id: string) =>
+	layout.find((entry) => entry.id === id)?.visible;
+
 describe("configuration", () => {
-	it("defaults to no brand ornament, collapsed tool details, and completion notifications", () => {
-		expect(DEFAULT_CONFIG.ornament).toBe("none");
+	it("defines complete defaults and compatibility templates", () => {
+		for (const template of [DEFAULT_CONFIG, ...Object.values(DISPLAY_TEMPLATES)]) {
+			expect(template.segmentLayout.map((entry) => entry.id)).toEqual(PRODUCT_SEGMENT_ORDER);
+			expect(new Set(template.segmentLayout.map((entry) => entry.id)).size).toBe(9);
+			expect(visibility(template.segmentLayout, "metrics")).toBe(true);
+			expect(visibility(template.segmentLayout, "context")).toBe(true);
+			expect(visibility(template.segmentLayout, "brand")).toBe(false);
+			expect(visibility(template.segmentLayout, "performance")).toBe(false);
+		}
 		expect(DEFAULT_CONFIG.showSidebarToolNames).toBe(false);
 		expect(DEFAULT_CONFIG.completionNotifications).toBe(true);
 	});
 
-	it("merges defaults, user, trusted project, then session overrides", async () => {
-		await writeJson(userPath, { preset: "classic", density: "compact" });
-		await writeJson(projectPath, { preset: "minimal", contextWarning: 65 });
+	it("merges user, trusted project, then session with actionable provenance", async () => {
+		await writeJson(userPath, { density: "compact" });
+		await writeJson(projectPath, {
+			segmentLayout: [
+				{ id: "context", visible: true },
+				{ id: "metrics", visible: true },
+			],
+		});
 		const result = await loadConfig({
 			userPath,
 			projectPath,
 			projectTrusted: true,
-			session: { ornament: "none" },
+			session: { segmentLayout: [{ id: "brand", visible: true }] },
 		});
-		expect(result.config).toMatchObject({
-			preset: "minimal",
-			density: "compact",
-			contextWarning: 65,
-			ornament: "none",
-		});
+		expect(result.config.density).toBe("compact");
+		expect(result.config.segmentLayout[0]).toEqual({ id: "brand", visible: true });
+		expect(result.displayProvenance.density).toBe("user");
+		expect(result.displayProvenance.order).toBe("session");
+		expect(result.displayProvenance.visibility.brand).toBe("session");
+		expect(result.config.preset).toBe("custom");
 	});
 
 	it("keeps completion notifications as a global user preference", async () => {
@@ -50,61 +65,95 @@ describe("configuration", () => {
 			projectTrusted: true,
 			session: { completionNotifications: true },
 		});
-
 		expect(result.config.completionNotifications).toBe(false);
 	});
 
-	it("does not let project configuration disable default-on completion notifications", async () => {
-		await writeJson(projectPath, { completionNotifications: false });
-		const result = await loadConfig({ userPath, projectPath, projectTrusted: true });
-
-		expect(result.config.completionNotifications).toBe(true);
-	});
-
-	it("does not read untrusted project configuration", async () => {
-		await writeJson(projectPath, { preset: "minimal" });
+	it("does not read, warn about, or attribute an untrusted project", async () => {
+		await writeFile(projectPath, "{broken", "utf8");
 		const result = await loadConfig({ userPath, projectPath, projectTrusted: false });
-		expect(result.config.preset).toBe("editorial");
-	});
-
-	it("accepts performance as an opt-in footer segment", () => {
-		expect(DEFAULT_CONFIG.segments).not.toContain("performance");
-
-		const result = validateConfig({
-			segments: ["activity", "performance", "metrics", "context"],
-		});
-
-		expect(result.config.segments).toEqual(["activity", "performance", "metrics", "context"]);
+		expect(result.config).toEqual(DEFAULT_CONFIG);
 		expect(result.warnings).toEqual([]);
+		expect(result.displayProvenance.order).toBe("product");
 	});
 
-	it("rejects invalid thresholds, duplicates, and unknown segments", () => {
+	it("makes a usable segmentLayout authoritative over same-layer legacy fields", () => {
 		const result = validateConfig({
-			contextWarning: 95,
-			contextDanger: 80,
-			segments: ["metrics", "metrics", "unknown"],
+			segmentLayout: [
+				{ id: "brand", visible: true },
+				{ id: "statuses", visible: true },
+			],
+			segments: ["metrics", "context"],
+			ornament: "none",
+			showExtensionStatuses: false,
 		});
-		expect(result.config.contextWarning).toBe(70);
-		expect(result.config.contextDanger).toBe(90);
-		expect(result.config.segments).toEqual(["metrics", "context"]);
-		expect(result.warnings).toEqual(
-			expect.arrayContaining([
-				expect.stringContaining("threshold"),
-				expect.stringContaining("duplicate"),
-				expect.stringContaining("unknown"),
-			]),
-		);
+		expect(visibility(result.config.segmentLayout, "brand")).toBe(true);
+		expect(visibility(result.config.segmentLayout, "statuses")).toBe(true);
 	});
 
-	it("validates boolean preferences", () => {
+	it("repairs malformed layouts deterministically and de-duplicates warnings", () => {
+		const result = validateConfig({
+			segmentLayout: [
+				{ id: "menu", visible: true },
+				{ id: "metrics", visible: false },
+				{ id: "menu", visible: false },
+				{ id: "mystery", visible: true },
+				{ id: "brand", visible: "yes" },
+				null,
+				null,
+			],
+		});
+		expect(result.config.segmentLayout.slice(0, 3)).toEqual([
+			{ id: "menu", visible: true },
+			{ id: "metrics", visible: true },
+			{ id: "brand", visible: false },
+		]);
+		expect(result.config.segmentLayout.map((entry) => entry.id)).toHaveLength(9);
+		expect(result.warnings.some((warning) => warning.includes("duplicate"))).toBe(true);
+		expect(result.warnings.filter((warning) => warning.includes("malformed"))).toHaveLength(1);
+	});
+
+	it("uses legacy fallback for non-array layouts and retains hidden omissions", () => {
+		const result = validateConfig({ segmentLayout: {}, segments: ["activity", "performance"] });
+		expect(result.warnings).toContain("segmentLayout must be an array");
+		expect(result.config.segmentLayout.map((entry) => entry.id).slice(0, 2)).toEqual([
+			"activity",
+			"performance",
+		]);
+		expect(visibility(result.config.segmentLayout, "performance")).toBe(true);
+		expect(visibility(result.config.segmentLayout, "git")).toBe(false);
+		expect(visibility(result.config.segmentLayout, "metrics")).toBe(true);
+	});
+
+	it.each([
+		[{ preset: "classic", ornament: "restrained", segments: ["brand"] }, true],
+		[{ preset: "editorial", ornament: "restrained", segments: ["brand"] }, false],
+		[{ preset: "classic", ornament: "none", segments: ["brand"] }, false],
+		[{ preset: "classic", ornament: "restrained", segments: [] }, false],
+	] as const)("reproduces legacy Brand compatibility for %j", (input, expected) => {
+		expect(visibility(validateConfig(input).config.segmentLayout, "brand")).toBe(expected);
+	});
+
+	it("reproduces legacy Statuses compatibility", () => {
 		expect(
-			validateConfig({ showSidebarToolNames: true, completionNotifications: false }).config,
-		).toMatchObject({ showSidebarToolNames: true, completionNotifications: false });
-		const invalid = validateConfig({ showSidebarToolNames: "yes", completionNotifications: "yes" });
-		expect(invalid.config.showSidebarToolNames).toBe(false);
-		expect(invalid.config.completionNotifications).toBe(true);
-		expect(invalid.warnings).toContain("showSidebarToolNames must be boolean");
-		expect(invalid.warnings).toContain("completionNotifications must be boolean");
+			visibility(
+				validateConfig({ segments: ["statuses"], showExtensionStatuses: false }).config.segmentLayout,
+				"statuses",
+			),
+		).toBe(false);
+		expect(
+			visibility(
+				validateConfig({ segments: ["statuses"], showExtensionStatuses: true }).config.segmentLayout,
+				"statuses",
+			),
+		).toBe(true);
+	});
+
+	it("rejects invalid thresholds and validates boolean preferences", () => {
+		const result = validateConfig({ contextWarning: 95, contextDanger: 80, showSidebarToolNames: "yes" });
+		expect(result.config.contextWarning).toBe(70);
+		expect(result.warnings).toEqual(
+			expect.arrayContaining([expect.stringContaining("threshold"), "showSidebarToolNames must be boolean"]),
+		);
 	});
 
 	it("reports malformed JSON once and retains defaults", async () => {
@@ -115,15 +164,14 @@ describe("configuration", () => {
 	});
 
 	it("saves valid JSON atomically without leaving temporary files", async () => {
-		await saveUserConfig(userPath, { ...DEFAULT_CONFIG, preset: "classic" });
-		expect(JSON.parse(await readFile(userPath, "utf8"))).toMatchObject({ preset: "classic" });
+		await saveUserConfig(userPath, { ...DEFAULT_CONFIG, preset: "custom" });
+		expect(JSON.parse(await readFile(userPath, "utf8"))).toMatchObject({ preset: "custom" });
 		expect((await readdir(root)).filter((name) => name.endsWith(".tmp"))).toEqual([]);
 	});
 
-	it("patches one user preference without persisting effective defaults or losing unknown fields", async () => {
+	it("patches one preference without losing unknown fields", async () => {
 		await writeJson(userPath, { density: "compact", futureSetting: "keep" });
 		await saveUserConfigPatch(userPath, { completionNotifications: false });
-
 		expect(JSON.parse(await readFile(userPath, "utf8"))).toEqual({
 			density: "compact",
 			futureSetting: "keep",

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -425,7 +425,7 @@ describe("extension registration", () => {
 		const before = h.custom.mock.calls.length;
 		await command(h, "display");
 		expect(h.custom.mock.calls.length).toBe(before + 1);
-		expect(h.overlays.at(-1)?.component.render(80).join("\n")).toContain("Display Settings");
+		expect(h.overlays.at(-1)?.component.render(80).join("\n")).toContain("DISPLAY SETTINGS");
 
 		const printed = harness("print");
 		await command(printed, "display");

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -183,6 +183,17 @@ describe("extension registration", () => {
 		expect(h.shortcuts).toContain("ctrl+shift+r");
 	});
 
+	it("routes alt+a to the Control Center", async () => {
+		const h = harness();
+		await start(h);
+		const before = h.custom.mock.calls.length;
+
+		await h.shortcutHandlers.get("alt+a")?.(h.ctx);
+
+		expect(h.custom.mock.calls.length).toBe(before + 1);
+		expect(h.overlays.at(-1)?.component.render(80).join("\n")).toContain("Atelier Control Center");
+	});
+
 	it("registers the resize shortcut exactly once across session replacement", async () => {
 		const h = harness();
 		await start(h);

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -232,18 +232,16 @@ describe("extension registration", () => {
 
 		await command(h, "sidebar tools on");
 
-		expect(h.saveConfig).toHaveBeenLastCalledWith(
-			expect.stringContaining("pi-atelier.json"),
-			expect.objectContaining({ showSidebarToolNames: true }),
-		);
+		expect(h.saveConfigPatch).toHaveBeenLastCalledWith(expect.stringContaining("pi-atelier.json"), {
+			showSidebarToolNames: true,
+		});
 		expect(h.overlays[0]?.component.render(44).join("\n")).toContain("read");
 		expect(h.ctx.ui.notify).toHaveBeenLastCalledWith("Sidebar tool list expanded", "info");
 
 		await command(h, "sidebar tools off");
-		expect(h.saveConfig).toHaveBeenLastCalledWith(
-			expect.stringContaining("pi-atelier.json"),
-			expect.objectContaining({ showSidebarToolNames: false }),
-		);
+		expect(h.saveConfigPatch).toHaveBeenLastCalledWith(expect.stringContaining("pi-atelier.json"), {
+			showSidebarToolNames: false,
+		});
 		expect(h.ctx.ui.notify).toHaveBeenLastCalledWith("Sidebar tool list collapsed", "info");
 	});
 

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -408,6 +408,20 @@ describe("extension registration", () => {
 		}
 	});
 
+	it("opens the Display workspace directly and rejects it outside TUI mode", async () => {
+		const h = harness();
+		await start(h);
+		const before = h.custom.mock.calls.length;
+		await command(h, "display");
+		expect(h.custom.mock.calls.length).toBe(before + 1);
+		expect(h.overlays.at(-1)?.component.render(80).join("\n")).toContain("Display Settings");
+
+		const printed = harness("print");
+		await command(printed, "display");
+		expect(printed.custom).not.toHaveBeenCalled();
+		expect(printed.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("TUI mode"), "warning");
+	});
+
 	it("warns instead of opening the sidebar outside TUI mode", async () => {
 		const h = harness("print");
 		await command(h, "sidebar");
@@ -583,27 +597,10 @@ describe("extension registration", () => {
 		try {
 			const h = harness();
 			await start(h);
-			const selections = ["display", "close"];
-			h.ctx.ui.select = vi.fn((title: string) =>
-				Promise.resolve(title === "Display controls" ? "Toggle segments" : "○ performance"),
-			);
-			h.ctx.ui.custom = vi.fn((factory: (...args: any[]) => any) => {
-				return new Promise<string | undefined>((resolve) => {
-					const done = vi.fn((value: string | undefined) => resolve(value));
-					factory(
-						{ requestRender: vi.fn() },
-						{
-							fg: (_color: string, text: string) => text,
-							bold: (text: string) => text,
-							italic: (text: string) => text,
-						},
-						{},
-						done,
-					);
-					done(selections.shift());
-				});
-			});
-			await command(h, "");
+			await command(h, "display");
+			const workspace = h.overlays.at(-1)?.component;
+			for (let index = 0; index < 5; index += 1) workspace.handleInput("\u001b[B");
+			workspace.handleInput(" ");
 
 			const footerRequestRender = vi.fn();
 			const footer = h.setFooter.mock.calls[0]?.[0](

--- a/tests/footer.test.ts
+++ b/tests/footer.test.ts
@@ -1,7 +1,7 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
+import { DISPLAY_TEMPLATES, legacySegmentsToLayout } from "../src/display.js";
 import { createFooterComponent, renderFooterLine, selectResponsiveMode } from "../src/footer.js";
-import { createMenuActions } from "../src/menu.js";
 import { type AtelierConfig, type AtelierState, DEFAULT_CONFIG } from "../src/types.js";
 
 const plainTheme = {
@@ -40,23 +40,17 @@ function firstWidthWithout(text: string, config = DEFAULT_CONFIG, renderState = 
 	throw new Error(`Expected ${text} to be removed`);
 }
 
-const actualClassicPresetConfig = (() => {
-	let config: AtelierConfig = DEFAULT_CONFIG;
-	const actions = createMenuActions(
-		{} as never,
-		{} as never,
-		{
-			getConfig: () => config,
-			setConfig: (next: AtelierConfig) => {
-				config = next;
-			},
-			refreshUsage: () => {},
-		},
-		"unused",
-	);
-	actions.setPreset("classic");
-	return config;
-})();
+const withVisible = (ids: Parameters<typeof legacySegmentsToLayout>[0], overrides = {}) => ({
+	...DEFAULT_CONFIG,
+	...overrides,
+	segmentLayout: legacySegmentsToLayout(ids),
+});
+
+const actualClassicPresetConfig: AtelierConfig = {
+	...DEFAULT_CONFIG,
+	...DISPLAY_TEMPLATES.classic,
+	segmentLayout: DISPLAY_TEMPLATES.classic.segmentLayout.map((entry) => ({ ...entry })),
+};
 
 const state: AtelierState = {
 	activity: "ready",
@@ -102,10 +96,7 @@ const state: AtelierState = {
 
 describe("footer performance", () => {
 	it("renders configured response performance in the Status Rail", () => {
-		const config: AtelierConfig = {
-			...DEFAULT_CONFIG,
-			segments: ["activity", "metrics", "performance", "context", "model", "menu"],
-		};
+		const config = withVisible(["activity", "metrics", "performance", "context", "model", "menu"]);
 		const line = stripAnsi(renderFooterLine(state, config, plainTheme, 160));
 
 		expect(line).toContain("TTFT ~ · TPS ~");
@@ -113,10 +104,7 @@ describe("footer performance", () => {
 	});
 
 	it("renders response performance after a response starts", () => {
-		const config: AtelierConfig = {
-			...DEFAULT_CONFIG,
-			segments: ["activity", "metrics", "performance", "context", "model", "menu"],
-		};
+		const config = withVisible(["activity", "metrics", "performance", "context", "model", "menu"]);
 		const line = stripAnsi(
 			renderFooterLine(
 				{ ...state, performance: { ttftMs: 820, tokensPerSecond: 42.34, estimated: true } },
@@ -130,10 +118,7 @@ describe("footer performance", () => {
 	});
 
 	it("keeps performance labels muted and dims each value until it is measured", () => {
-		const config: AtelierConfig = {
-			...DEFAULT_CONFIG,
-			segments: ["activity", "metrics", "performance", "context", "model", "menu"],
-		};
+		const config = withVisible(["activity", "metrics", "performance", "context", "model", "menu"]);
 		const theme = namedTheme("dark");
 
 		const idle = renderFooterLine(state, config, theme, 400);
@@ -155,10 +140,7 @@ describe("footer performance", () => {
 
 	describe("responsive performance", () => {
 		it("drops performance as one item when the footer is narrow", () => {
-			const config: AtelierConfig = {
-				...DEFAULT_CONFIG,
-				segments: ["activity", "metrics", "performance", "context", "model", "menu"],
-			};
+			const config = withVisible(["activity", "metrics", "performance", "context", "model", "menu"]);
 			const line = stripAnsi(
 				renderFooterLine(
 					{ ...state, performance: { ttftMs: 820, tokensPerSecond: 42.34 } },
@@ -222,7 +204,9 @@ describe("footer", () => {
 		const config: AtelierConfig = {
 			...DEFAULT_CONFIG,
 			preset: "classic",
-			ornament: "restrained",
+			segmentLayout: DEFAULT_CONFIG.segmentLayout.map((entry) =>
+				entry.id === "brand" ? { ...entry, visible: true } : { ...entry },
+			),
 		};
 		const configuredState = { ...state, extensionStatuses: ["INDEXING"] };
 		expect(plainAt(180, config, configuredState)).toEqual(expect.stringContaining("ATELIER"));
@@ -484,12 +468,37 @@ describe("footer", () => {
 		expect(line).not.toContain("ATELIER");
 	});
 
-	it("honors ornament, preset, density, and configured item order", () => {
+	it("uses normalized layout as the sole Brand and Statuses visibility source", () => {
+		const visible = withVisible(["brand", "activity", "metrics", "context", "statuses"], {
+			preset: "editorial",
+			showExtensionStatuses: false,
+		}) as AtelierConfig;
+		const line = renderFooterLine({ ...state, extensionStatuses: ["INDEXING"] }, visible, plainTheme, 180);
+		expect(line).toContain("ATELIER");
+		expect(line).toContain("INDEXING");
+
+		const hidden = withVisible(["activity", "metrics", "context"], {
+			preset: "classic",
+			showExtensionStatuses: true,
+		}) as AtelierConfig;
+		const hiddenLine = renderFooterLine(
+			{ ...state, extensionStatuses: ["INDEXING"] },
+			hidden,
+			plainTheme,
+			180,
+		);
+		expect(hiddenLine).not.toContain("ATELIER");
+		expect(hiddenLine).not.toContain("INDEXING");
+	});
+
+	it("honors preset, density, and configured item order", () => {
 		const defaultLine = renderFooterLine(state, DEFAULT_CONFIG, plainTheme, 180);
 		expect(defaultLine).not.toContain("ATELIER");
 		const ornament = renderFooterLine(
 			state,
-			{ ...DEFAULT_CONFIG, preset: "classic", ornament: "restrained" },
+			withVisible(["brand", "activity", "metrics", "context", "model", "git", "statuses", "menu"], {
+				preset: "classic",
+			}),
 			plainTheme,
 			180,
 		);
@@ -506,21 +515,12 @@ describe("footer", () => {
 		expect(compact).toContain("● WORKING");
 		expect(compact).not.toContain("PONDERING");
 
-		const reordered = renderFooterLine(
-			state,
-			{ ...DEFAULT_CONFIG, segments: ["context", "metrics"] },
-			plainTheme,
-			160,
-		);
+		const reordered = renderFooterLine(state, withVisible(["context", "metrics"]), plainTheme, 160);
 		expect(reordered.indexOf("ctx 27.0%")).toBeLessThan(reordered.indexOf("in 324k"));
-		const contextOnly = renderFooterLine(
-			state,
-			{ ...DEFAULT_CONFIG, segments: ["context"] },
-			plainTheme,
-			160,
-		);
+		const contextOnly = renderFooterLine(state, withVisible(["context"]), plainTheme, 160);
 		expect(contextOnly).toContain("ctx 27.0%");
-		expect(contextOnly).not.toContain("in 324k");
+		// Required metrics remains visible even when omitted by a legacy-style fixture.
+		expect(contextOnly).toContain("in 324k");
 		expect(contextOnly).not.toContain("● READY");
 	});
 
@@ -612,7 +612,16 @@ describe("footer", () => {
 	it("generates each item at most once for duplicate configured categories", () => {
 		const line = renderFooterLine(
 			state,
-			{ ...DEFAULT_CONFIG, segments: ["activity", "metrics", "metrics", "context", "context"] },
+			{
+				...DEFAULT_CONFIG,
+				segmentLayout: [
+					{ id: "activity", visible: true },
+					{ id: "metrics", visible: true },
+					{ id: "metrics", visible: true },
+					{ id: "context", visible: true },
+					{ id: "context", visible: true },
+				],
+			},
 			plainTheme,
 			180,
 		);
@@ -681,7 +690,12 @@ describe("footer", () => {
 		try {
 			expect(component.render(20)[0]).not.toContain("PONDERING");
 			expect(vi.getTimerCount()).toBe(0);
-			config = { ...DEFAULT_CONFIG, segments: DEFAULT_CONFIG.segments.filter((id) => id !== "activity") };
+			config = {
+				...DEFAULT_CONFIG,
+				segmentLayout: DEFAULT_CONFIG.segmentLayout.map((entry) =>
+					entry.id === "activity" ? { ...entry, visible: false } : { ...entry },
+				),
+			};
 			expect(component.render(100)[0]).not.toContain("PONDERING");
 			expect(vi.getTimerCount()).toBe(0);
 			config = DEFAULT_CONFIG;
@@ -712,7 +726,9 @@ describe("footer", () => {
 			}),
 			getConfig: () => ({
 				...DEFAULT_CONFIG,
-				segments: DEFAULT_CONFIG.segments.filter((id) => id !== "activity"),
+				segmentLayout: DEFAULT_CONFIG.segmentLayout.map((entry) =>
+					entry.id === "activity" ? { ...entry, visible: false } : { ...entry },
+				),
 			}),
 			requestRender: vi.fn(),
 			onBranchChange: () => vi.fn(),

--- a/tests/menu.test.ts
+++ b/tests/menu.test.ts
@@ -14,14 +14,15 @@ vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
 	};
 });
 
+import { derivePresetIdentity } from "../src/display.js";
 import {
 	createMenuActions,
+	openAtelierControlCenter,
 	openAtelierMenu,
 	renderMenuBorder,
 	renderMenuFrame,
 	type SidebarControls,
 } from "../src/menu.js";
-import { derivePresetIdentity } from "../src/display.js";
 import { DEFAULT_CONFIG, type DisplayPatch } from "../src/types.js";
 
 function harness() {
@@ -82,11 +83,15 @@ describe("Control Center presentation", () => {
 			compact: vi.fn(),
 			ui: {
 				notify: vi.fn(),
-				custom: vi.fn((factory: (...args: any[]) => unknown) => {
+				custom: vi.fn((factory: (...args: any[]) => unknown, _options?: unknown) => {
 					const value = values.shift();
 					factory(
 						{ requestRender: vi.fn() },
-						{ fg: (_color: string, text: string) => text, bold: (text: string) => text },
+						{
+							fg: (_color: string, text: string) => text,
+							bold: (text: string) => text,
+							italic: (text: string) => text,
+						},
 						{},
 						vi.fn(),
 					);
@@ -113,6 +118,53 @@ describe("Control Center presentation", () => {
 		);
 		expect(rootMenuItems[0]?.map((item) => item.label)).toEqual(["Settings", "Controls", "Actions", "Close"]);
 		expect(rootMenuItems[0]?.find((item) => item.value === "controls")?.description).toContain("Sidebar: On");
+	});
+
+	it.each([
+		[
+			"settings",
+			["Display: editorial", "Completion notifications: On", "Sidebar tool list: Collapsed", "Back"],
+		],
+		["actions", ["Session details", "Rename session", "Compact session", "Back"]],
+	] as const)("routes the %s root category to its destination", async (category, expectedLabels) => {
+		rootMenuItems.length = 0;
+		const sidebar: SidebarControls = {
+			isVisible: vi.fn(() => true),
+			toggle: vi.fn(),
+			isToolListExpanded: vi.fn(() => false),
+			toggleToolList: vi.fn().mockResolvedValue(undefined),
+		};
+		await openAtelierMenu(
+			{} as never,
+			contextWithSelections([category, "back", "close"]) as never,
+			harness().runtime as never,
+			"/tmp/user.json",
+			sidebar,
+		);
+		expect(rootMenuItems[1]?.map((item) => item.label)).toEqual(expectedLabels);
+	});
+
+	it("routes Control Center Settings → Display to the workspace", async () => {
+		rootMenuItems.length = 0;
+		const ctx = contextWithSelections(["settings", "display", "workspace-close", "back", "close"]);
+		const sidebar: SidebarControls = {
+			isVisible: vi.fn(() => true),
+			toggle: vi.fn(),
+			isToolListExpanded: vi.fn(() => false),
+			toggleToolList: vi.fn().mockResolvedValue(undefined),
+		};
+		await openAtelierControlCenter(
+			{} as never,
+			ctx as never,
+			harness().runtime as never,
+			"/tmp/user.json",
+			sidebar,
+		);
+		expect(ctx.ui.custom).toHaveBeenCalledTimes(5);
+		expect(ctx.ui.custom.mock.calls[2]?.[1]).toMatchObject({
+			overlay: true,
+			overlayOptions: expect.objectContaining({ width: "90%" }),
+		});
 	});
 
 	it("keeps Sidebar visibility in Controls and session-scoped", async () => {

--- a/tests/menu.test.ts
+++ b/tests/menu.test.ts
@@ -21,12 +21,25 @@ import {
 	renderMenuFrame,
 	type SidebarControls,
 } from "../src/menu.js";
-import { DEFAULT_CONFIG } from "../src/types.js";
+import { derivePresetIdentity } from "../src/display.js";
+import { DEFAULT_CONFIG, type DisplayPatch } from "../src/types.js";
 
 function harness() {
-	let config = { ...DEFAULT_CONFIG, segments: [...DEFAULT_CONFIG.segments] };
+	let config = {
+		...DEFAULT_CONFIG,
+		segmentLayout: DEFAULT_CONFIG.segmentLayout.map((entry) => ({ ...entry })),
+	};
 	const runtime = {
 		getConfig: vi.fn(() => config),
+		getDisplaySettings: vi.fn(() => ({
+			preset: config.preset,
+			density: config.density,
+			segmentLayout: config.segmentLayout.map((entry) => ({ ...entry })),
+		})),
+		setSessionDisplayPatch: vi.fn((patch: DisplayPatch) => {
+			config = { ...config, ...patch };
+			config.preset = derivePresetIdentity(config);
+		}),
 		setConfig: vi.fn((next) => {
 			config = next;
 		}),
@@ -200,7 +213,9 @@ describe("menu presentation", () => {
 		await openAtelierMenu({} as never, ctx as never, h.runtime as never, "/tmp/user.json", sidebar);
 
 		expect(offered).toContain("○ performance");
-		expect(h.runtime.getConfig().segments).toContain("performance");
+		expect(h.runtime.getConfig().segmentLayout.find((entry) => entry.id === "performance")?.visible).toBe(
+			true,
+		);
 	});
 
 	it("shows and toggles collapsed sidebar tool details", async () => {
@@ -261,6 +276,43 @@ describe("menu presentation", () => {
 });
 
 describe("menu actions", () => {
+	it.each([
+		["editorial", ["activity", "metrics", "context", "model", "git", "statuses", "menu"]],
+		["minimal", ["activity", "metrics", "context", "model", "menu"]],
+		["classic", ["metrics", "context", "model", "git", "statuses"]],
+	] as const)("applies the complete %s template", (preset, visible) => {
+		const h = harness();
+		h.actions.setPreset(preset);
+		expect(h.runtime.getConfig().segmentLayout).toHaveLength(9);
+		expect(
+			h.runtime
+				.getConfig()
+				.segmentLayout.filter((entry) => entry.visible)
+				.map((entry) => entry.id),
+		).toEqual(visible);
+		expect(h.runtime.getConfig().preset).toBe(preset);
+	});
+
+	it("toggles in place, protects required entries, and reorders across hidden neighbors", () => {
+		const h = harness();
+		const initialOrder = h.runtime.getConfig().segmentLayout.map((entry) => entry.id);
+		h.actions.toggleSegment("performance");
+		h.actions.toggleSegment("metrics");
+		expect(h.runtime.getConfig().segmentLayout.map((entry) => entry.id)).toEqual(initialOrder);
+		expect(h.runtime.getConfig().segmentLayout.find((entry) => entry.id === "performance")?.visible).toBe(
+			true,
+		);
+		expect(h.runtime.getConfig().segmentLayout.find((entry) => entry.id === "metrics")?.visible).toBe(true);
+		h.actions.moveSegment("context", "earlier");
+		expect(
+			h.runtime
+				.getConfig()
+				.segmentLayout.map((entry) => entry.id)
+				.slice(2, 5),
+		).toEqual(["metrics", "context", "performance"]);
+		expect(h.runtime.getConfig().preset).toBe("custom");
+	});
+
 	it("keeps the prior model when authentication fails", async () => {
 		const h = harness();
 		h.pi.setModel.mockResolvedValue(false);
@@ -301,8 +353,8 @@ describe("menu actions", () => {
 		h.actions.setPreset("minimal");
 		expect(h.save).not.toHaveBeenCalled();
 		await h.actions.saveDisplayDefaults();
-		expect(h.save).toHaveBeenCalledOnce();
-		expect(h.runtime.setConfig).toHaveBeenCalled();
+		expect(h.savePatch).toHaveBeenCalledWith("/tmp/user.json", h.runtime.getDisplaySettings());
+		expect(h.save).not.toHaveBeenCalled();
 	});
 
 	it("restores the ornament-free Status Rail defaults when selecting editorial", () => {
@@ -313,8 +365,7 @@ describe("menu actions", () => {
 		h.actions.setPreset("editorial");
 		expect(h.runtime.getConfig()).toMatchObject({
 			preset: "editorial",
-			segments: DEFAULT_CONFIG.segments,
-			ornament: "none",
+			segmentLayout: DEFAULT_CONFIG.segmentLayout,
 			density: "comfortable",
 		});
 	});
@@ -327,10 +378,14 @@ describe("menu actions", () => {
 		h.actions.setPreset("classic");
 		expect(h.runtime.getConfig()).toMatchObject({
 			preset: "classic",
-			segments: ["metrics", "context", "model", "git", "statuses"],
 			density: "comfortable",
-			ornament: "none",
 		});
+		expect(
+			h.runtime
+				.getConfig()
+				.segmentLayout.filter((entry) => entry.visible)
+				.map((entry) => entry.id),
+		).toEqual(["metrics", "context", "model", "git", "statuses"]);
 	});
 
 	it("renames a session only after non-empty input", async () => {
@@ -355,9 +410,9 @@ describe("menu actions", () => {
 		h.actions.setDensity("compact");
 		h.actions.setOrnament("none");
 		h.actions.moveSegment("context", "earlier");
-		expect(h.runtime.getConfig()).toMatchObject({ density: "compact", ornament: "none" });
-		expect(h.runtime.getConfig().segments.indexOf("context")).toBeLessThan(
-			h.runtime.getConfig().segments.indexOf("metrics"),
+		expect(h.runtime.getConfig()).toMatchObject({ density: "compact", preset: "custom" });
+		expect(h.runtime.getConfig().segmentLayout.findIndex((entry) => entry.id === "context")).toBeLessThan(
+			h.runtime.getConfig().segmentLayout.findIndex((entry) => entry.id === "performance"),
 		);
 	});
 

--- a/tests/menu.test.ts
+++ b/tests/menu.test.ts
@@ -72,153 +72,31 @@ function harness() {
 	return { actions, pi, ctx, runtime, save, savePatch };
 }
 
-describe("menu presentation", () => {
-	it.each([
-		[
-			false,
-			{
-				value: "sidebar",
-				label: "Sidebar: Off",
-				description: "Show the docked information rail",
-			},
-		],
-		[
-			true,
-			{
-				value: "sidebar",
-				label: "Sidebar: On",
-				description: "Hide the docked information rail",
-			},
-		],
-	] as const)("shows and toggles the dynamic sidebar state (%s)", async (visible, expected) => {
-		rootMenuItems.length = 0;
-		const sidebar: SidebarControls = {
-			isVisible: vi.fn(() => visible),
-			toggle: vi.fn(),
-			isToolListExpanded: vi.fn(() => false),
-			toggleToolList: vi.fn().mockResolvedValue(undefined),
-		};
-		let invocation = 0;
-		const ctx = {
+describe("Control Center presentation", () => {
+	function contextWithSelections(values: string[]) {
+		return {
 			mode: "tui",
-			ui: {
-				custom: vi.fn(
-					(factory: (...args: any[]) => unknown) =>
-						new Promise((resolve) => {
-							const value = invocation++ === 0 ? "sidebar" : "close";
-							factory(
-								{ requestRender: vi.fn() },
-								{ fg: (_color: string, text: string) => text, bold: (text: string) => text },
-								{},
-								resolve,
-							);
-							resolve(value);
-						}),
-				),
-			},
-		};
-
-		await openAtelierMenu({} as never, ctx as never, harness().runtime as never, "/tmp/user.json", sidebar);
-
-		expect(rootMenuItems[0]).toContainEqual(expected);
-		expect(sidebar.toggle).toHaveBeenCalledOnce();
-	});
-
-	it("shows and persists the completion notification toggle", async () => {
-		rootMenuItems.length = 0;
-		const h = harness();
-		const sidebar: SidebarControls = {
-			isVisible: vi.fn(() => false),
-			toggle: vi.fn(),
-			isToolListExpanded: vi.fn(() => false),
-			toggleToolList: vi.fn().mockResolvedValue(undefined),
-		};
-		let invocation = 0;
-		const ctx = {
-			mode: "tui",
+			model: { id: "old", provider: "provider" },
+			modelRegistry: { getAvailable: vi.fn().mockReturnValue([]) },
+			sessionManager: { getSessionFile: vi.fn().mockReturnValue("/tmp/session.jsonl") },
+			compact: vi.fn(),
 			ui: {
 				notify: vi.fn(),
-				custom: vi.fn(
-					(factory: (...args: any[]) => unknown) =>
-						new Promise((resolve) => {
-							const value = invocation++ === 0 ? "notifications" : "close";
-							factory(
-								{ requestRender: vi.fn() },
-								{ fg: (_color: string, text: string) => text, bold: (text: string) => text },
-								{},
-								resolve,
-							);
-							resolve(value);
-						}),
-				),
-			},
-		};
-
-		await openAtelierMenu(
-			{} as never,
-			ctx as never,
-			h.runtime as never,
-			"/tmp/user.json",
-			sidebar,
-			h.save,
-			h.savePatch,
-		);
-
-		expect(rootMenuItems[0]).toContainEqual({
-			value: "notifications",
-			label: "Completion notifications: On",
-			description: "Notify when a turn settles or Pi requests input",
-		});
-		expect(h.runtime.getConfig().completionNotifications).toBe(false);
-		expect(h.savePatch).toHaveBeenCalledWith("/tmp/user.json", { completionNotifications: false });
-		expect(h.save).not.toHaveBeenCalled();
-	});
-
-	it("offers performance in the segment toggle and enables it", async () => {
-		rootMenuItems.length = 0;
-		const h = harness();
-		const sidebar: SidebarControls = {
-			isVisible: vi.fn(() => false),
-			toggle: vi.fn(),
-			isToolListExpanded: vi.fn(() => false),
-			toggleToolList: vi.fn().mockResolvedValue(undefined),
-		};
-		let invocation = 0;
-		let offered: string[] = [];
-		const ctx = {
-			mode: "tui",
-			ui: {
-				notify: vi.fn(),
-				select: vi.fn((title: string, options: string[]) => {
-					if (title !== "Toggle footer segment") return Promise.resolve("Toggle segments");
-					offered = options;
-					return Promise.resolve("○ performance");
+				custom: vi.fn((factory: (...args: any[]) => unknown) => {
+					const value = values.shift();
+					factory(
+						{ requestRender: vi.fn() },
+						{ fg: (_color: string, text: string) => text, bold: (text: string) => text },
+						{},
+						vi.fn(),
+					);
+					return Promise.resolve(value);
 				}),
-				custom: vi.fn(
-					(factory: (...args: any[]) => unknown) =>
-						new Promise((resolve) => {
-							const value = invocation++ === 0 ? "display" : "close";
-							factory(
-								{ requestRender: vi.fn() },
-								{ fg: (_color: string, text: string) => text, bold: (text: string) => text },
-								{},
-								resolve,
-							);
-							resolve(value);
-						}),
-				),
 			},
 		};
+	}
 
-		await openAtelierMenu({} as never, ctx as never, h.runtime as never, "/tmp/user.json", sidebar);
-
-		expect(offered).toContain("○ performance");
-		expect(h.runtime.getConfig().segmentLayout.find((entry) => entry.id === "performance")?.visible).toBe(
-			true,
-		);
-	});
-
-	it("shows and toggles collapsed sidebar tool details", async () => {
+	it("partitions Settings, Controls, and Actions at the root with current Sidebar state", async () => {
 		rootMenuItems.length = 0;
 		const sidebar: SidebarControls = {
 			isVisible: vi.fn(() => true),
@@ -226,51 +104,46 @@ describe("menu presentation", () => {
 			isToolListExpanded: vi.fn(() => false),
 			toggleToolList: vi.fn().mockResolvedValue(undefined),
 		};
-		let invocation = 0;
-		const ctx = {
-			mode: "tui",
-			ui: {
-				custom: vi.fn(
-					(factory: (...args: any[]) => unknown) =>
-						new Promise((resolve) => {
-							const value = invocation++ === 0 ? "sidebar-tools" : "close";
-							factory(
-								{ requestRender: vi.fn() },
-								{ fg: (_color: string, text: string) => text, bold: (text: string) => text },
-								{},
-								resolve,
-							);
-							resolve(value);
-						}),
-				),
-			},
+		await openAtelierMenu(
+			{} as never,
+			contextWithSelections(["close"]) as never,
+			harness().runtime as never,
+			"/tmp/user.json",
+			sidebar,
+		);
+		expect(rootMenuItems[0]?.map((item) => item.label)).toEqual(["Settings", "Controls", "Actions", "Close"]);
+		expect(rootMenuItems[0]?.find((item) => item.value === "controls")?.description).toContain("Sidebar: On");
+	});
+
+	it("keeps Sidebar visibility in Controls and session-scoped", async () => {
+		rootMenuItems.length = 0;
+		const sidebar: SidebarControls = {
+			isVisible: vi.fn(() => true),
+			toggle: vi.fn(),
+			isToolListExpanded: vi.fn(() => false),
+			toggleToolList: vi.fn().mockResolvedValue(undefined),
 		};
-
-		await openAtelierMenu({} as never, ctx as never, harness().runtime as never, "/tmp/user.json", sidebar);
-
-		expect(rootMenuItems[0]).toContainEqual({
-			value: "sidebar-tools",
-			label: "Tool list: Collapsed",
-			description: "Show active tool names in the sidebar",
-		});
-		expect(sidebar.toggleToolList).toHaveBeenCalledOnce();
+		await openAtelierMenu(
+			{
+				getThinkingLevel: vi.fn().mockReturnValue("medium"),
+				getActiveTools: vi.fn().mockReturnValue([]),
+			} as never,
+			contextWithSelections(["controls", "sidebar", "back", "close"]) as never,
+			harness().runtime as never,
+			"/tmp/user.json",
+			sidebar,
+		);
+		expect(sidebar.toggle).toHaveBeenCalledOnce();
 	});
 
 	it("uses a heavy theme-aware border that fills the available width", () => {
-		const theme = {
-			fg: vi.fn((_color: string, text: string) => text),
-			bold: vi.fn((text: string) => text),
-		};
+		const theme = { fg: vi.fn((_color: string, text: string) => text), bold: vi.fn((text: string) => text) };
 		expect(renderMenuBorder(theme, 6)).toBe("━━━━━━");
 		expect(theme.fg).toHaveBeenCalledWith("borderAccent", "━━━━━━");
-		expect(theme.bold).toHaveBeenCalled();
 	});
 
 	it("frames every content row with heavy vertical borders and corners", () => {
-		const theme = {
-			fg: (_color: string, text: string) => text,
-			bold: (text: string) => text,
-		};
+		const theme = { fg: (_color: string, text: string) => text, bold: (text: string) => text };
 		expect(renderMenuFrame(theme, ["Hi"], 8)).toEqual(["┏━━━━━━┓", "┃Hi    ┃", "┗━━━━━━┛"]);
 	});
 });

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -24,4 +24,12 @@ describe("npm package contract", () => {
 		expect(readme).toContain("72");
 		expect(readme).toContain("version-sensitive");
 	});
+
+	it("publishes the direct Display workspace and keyboard contract", async () => {
+		const readme = await readFile(new URL("../README.md", import.meta.url), "utf8");
+		expect(readme).toContain("/atelier display");
+		expect(readme).toContain("Shift+Up/Shift+Down");
+		expect(readme).toContain("Undo");
+		expect(readme).toContain("Revert");
+	});
 });

--- a/tests/settings-workspace.test.ts
+++ b/tests/settings-workspace.test.ts
@@ -1,0 +1,152 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { resolveDisplayLayers } from "../src/config.js";
+import { createSettingsWorkspace } from "../src/settings-workspace.js";
+import { DEFAULT_CONFIG, type DisplayLayerState, type DisplayPatch } from "../src/types.js";
+
+const theme = {
+	fg: (_color: string, text: string) => text,
+	bold: (text: string) => text,
+	italic: (text: string) => text,
+};
+
+function harness() {
+	let layers: DisplayLayerState = {};
+	const render = vi.fn();
+	const live = vi.fn();
+	const close = vi.fn();
+	const persist = vi.fn<(patch: DisplayPatch) => Promise<void>>().mockResolvedValue(undefined);
+	const component = createSettingsWorkspace({
+		getDisplaySettings: () => resolveDisplayLayers(layers).display,
+		getDisplayProvenance: () => resolveDisplayLayers(layers).provenance,
+		getSessionDisplayOverride: () => layers.session as never,
+		replaceSessionDisplayOverride: (value) => {
+			const { session: _old, ...lower } = layers;
+			layers = value ? { ...lower, session: structuredClone(value) as Record<string, unknown> } : lower;
+		},
+		clearSessionDisplayOverride: () => {
+			const { session: _old, ...lower } = layers;
+			layers = lower;
+		},
+		persistUserDisplayPatch: persist,
+		applySavedUserDisplayPatch: (patch) => {
+			layers = { ...layers, user: { ...layers.user, ...structuredClone(patch) } };
+		},
+		getRenderConfig: () => DEFAULT_CONFIG,
+		theme,
+		colorEnabled: false,
+		requestWorkspaceRender: render,
+		requestLiveRender: live,
+		close,
+	});
+	return {
+		component,
+		render,
+		live,
+		close,
+		persist,
+		get layers() {
+			return layers;
+		},
+	};
+}
+
+const text = (component: ReturnType<typeof createSettingsWorkspace>, width = 120) =>
+	component.render(width).join("\n");
+
+describe("Display Settings Workspace", () => {
+	it("applies a complete preset continuously as one Session mutation and one Undo step", () => {
+		const h = harness();
+		h.component.handleInput(" ");
+		expect(resolveDisplayLayers(h.layers).display).toMatchObject({ preset: "minimal", density: "compact" });
+		expect(text(h.component)).toContain("minimal");
+		expect(h.live).toHaveBeenCalledOnce();
+		h.component.handleInput("u");
+		expect(h.layers.session).toBeUndefined();
+		expect(resolveDisplayLayers(h.layers).display.preset).toBe("editorial");
+	});
+
+	it("accumulates Segment edits, protects required entries, and retains overrides on close", () => {
+		const h = harness();
+		// Focus performance (preset, density, brand, activity, metrics, performance).
+		for (let index = 0; index < 5; index += 1) h.component.handleInput("\u001b[B");
+		h.component.handleInput(" ");
+		expect(
+			resolveDisplayLayers(h.layers).display.segmentLayout.find((entry) => entry.id === "performance")
+				?.visible,
+		).toBe(true);
+		// metrics is required and rejects toggling.
+		h.component.handleInput("\u001b[A");
+		h.component.handleInput(" ");
+		expect(text(h.component)).toContain("metrics is required");
+		h.component.handleInput("\u001b");
+		expect(h.close).toHaveBeenCalledOnce();
+		expect(h.layers.session).toBeDefined();
+	});
+
+	it("supports Revert and one-step Undo of Revert without touching lower layers", () => {
+		const h = harness();
+		h.component.handleInput(" ");
+		h.component.handleInput("r");
+		expect(h.layers.session).toBeUndefined();
+		h.component.handleInput("u");
+		expect(resolveDisplayLayers(h.layers).display.preset).toBe("minimal");
+	});
+
+	it("persists the current Display as the User default and keeps the workspace open", async () => {
+		const h = harness();
+		h.component.handleInput(" ");
+		h.component.handleInput("s");
+		await vi.waitFor(() => expect(text(h.component)).toContain("Saved as User default"));
+		expect(h.persist).toHaveBeenCalledOnce();
+		expect(h.layers.user).toMatchObject({ preset: "minimal", density: "compact" });
+		expect(h.close).not.toHaveBeenCalled();
+	});
+
+	it("saves only Display fields and keeps failed saves and Undo history intact", async () => {
+		const h = harness();
+		h.component.handleInput(" ");
+		h.persist.mockRejectedValueOnce(new Error("disk full"));
+		h.component.handleInput("s");
+		await vi.waitFor(() => expect(text(h.component)).toContain("Save failed: disk full"));
+		expect(h.layers.session).toBeDefined();
+		h.component.handleInput("u");
+		expect(h.layers.session).toBeUndefined();
+		expect(h.persist.mock.calls[0]?.[0]).toEqual(
+			expect.objectContaining({ preset: "minimal", density: "compact", segmentLayout: expect.any(Array) }),
+		);
+		expect(Object.keys(h.persist.mock.calls[0]?.[0] ?? {}).sort()).toEqual([
+			"density",
+			"preset",
+			"segmentLayout",
+		]);
+	});
+
+	it.each([40, 80, 120])(
+		"renders one native-background rounded frame without overflow at %s columns",
+		(width) => {
+			const h = harness();
+			const lines = h.component.render(width);
+			expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+			expect(
+				lines.filter(
+					(line) => line.includes("╭") || line.includes("╮") || line.includes("╰") || line.includes("╯"),
+				),
+			).toHaveLength(2);
+			expect(lines[0]).toContain("╭");
+			expect(lines.at(-1)).toContain("╰");
+		},
+	);
+
+	it("uses stacked panels narrowly and equal-bottom side-by-side panels widely", () => {
+		const h = harness();
+		const narrow = h.component.render(40);
+		expect(narrow.findIndex((line) => line.includes(" Display "))).toBeLessThan(
+			narrow.findIndex((line) => line.includes(" Segments ")),
+		);
+		const wide = h.component.render(120);
+		const sideBySide = wide.find((line) => line.includes(" Display ") && line.includes(" Segments "));
+		expect(sideBySide).toBeDefined();
+		expect(wide.some((line) => (line.match(/└/g) ?? []).length === 2)).toBe(true);
+	});
+});

--- a/tests/settings-workspace.test.ts
+++ b/tests/settings-workspace.test.ts
@@ -147,7 +147,7 @@ describe("Display Settings Workspace", () => {
 		});
 		const rendered = text(h.component);
 		expect(rendered).toContain("Density      compact       user");
-		expect(rendered).toContain("order:user");
+		expect(rendered).toContain("order user");
 		expect(rendered).not.toContain("brand › activity");
 		expect(rendered.indexOf("1  ○ brand")).toBeLessThan(rendered.indexOf("2  ● activity"));
 		expect(rendered.indexOf("2  ● activity")).toBeLessThan(rendered.indexOf("3  ◆ metrics"));
@@ -168,7 +168,7 @@ describe("Display Settings Workspace", () => {
 		expect(lines.join("\n")).not.toContain("brand        ATELIER");
 	});
 
-	it("keeps value and provenance columns fixed while focus moves", () => {
+	it("keeps value, provenance, and action shortcut columns fixed", () => {
 		const h = harness();
 		const before = h.component.render(120);
 		h.component.handleInput("\u001b[B");
@@ -183,6 +183,11 @@ describe("Display Settings Workspace", () => {
 			);
 			expect(beforeLine?.indexOf("product")).toBe(afterLine?.indexOf("product"));
 		}
+		const save = before.find((line) => line.includes("Save default"));
+		const revert = before.find((line) => line.includes("Revert session"));
+		const undo = before.find((line) => line.includes("Undo"));
+		expect(save?.lastIndexOf("S")).toBe(revert?.lastIndexOf("R"));
+		expect(revert?.lastIndexOf("R")).toBe(undo?.lastIndexOf("—"));
 	});
 
 	it("uses stacked panels narrowly and equal-bottom side-by-side panels widely", () => {

--- a/tests/settings-workspace.test.ts
+++ b/tests/settings-workspace.test.ts
@@ -10,8 +10,8 @@ const theme = {
 	italic: (text: string) => text,
 };
 
-function harness() {
-	let layers: DisplayLayerState = {};
+function harness(initialLayers: DisplayLayerState = {}) {
+	let layers: DisplayLayerState = structuredClone(initialLayers);
 	const render = vi.fn();
 	const live = vi.fn();
 	const close = vi.fn();
@@ -137,6 +137,64 @@ describe("Display Settings Workspace", () => {
 			expect(lines.at(-1)).toContain("╰");
 		},
 	);
+
+	it("shows layout-order provenance with effective values", () => {
+		const h = harness({
+			user: {
+				density: "compact",
+				segmentLayout: DEFAULT_CONFIG.segmentLayout.map((entry) => ({ ...entry })),
+			},
+		});
+		const rendered = text(h.component);
+		expect(rendered).toContain("Density    compact      user");
+		expect(rendered).toContain("Order      user");
+		expect(rendered.indexOf("brand        hidden")).toBeLessThan(rendered.indexOf("activity     shown"));
+		expect(rendered.indexOf("activity     shown")).toBeLessThan(rendered.indexOf("metrics      required"));
+	});
+
+	it.each([40, 80, 120])(
+		"uses real footer rendering to expose every enabled Segment at %s columns",
+		(width) => {
+			const h = harness({
+				user: {
+					segmentLayout: DEFAULT_CONFIG.segmentLayout.map((entry) => ({ ...entry, visible: true })),
+				},
+			});
+			const lines = h.component.render(width);
+			const rendered = lines.join("\n");
+			expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+			for (const evidence of [
+				"brand        ATELIER",
+				"activity     ● CRAFTING",
+				"performance  TTFT 680ms",
+				"context      ctx 25.0% (auto)",
+				"model        artisan-1 · high",
+				"git          feat/settings*",
+				"statuses     SYNC",
+				"menu         ⌥A",
+			]) {
+				expect(rendered).toContain(evidence);
+			}
+			expect(rendered).toMatch(/metrics\s+.*cache 72%/);
+		},
+	);
+
+	it("keeps value and provenance columns fixed while focus moves", () => {
+		const h = harness();
+		const before = h.component.render(120);
+		h.component.handleInput("\u001b[B");
+		const after = h.component.render(120);
+		for (const label of ["Preset", "Density"]) {
+			const beforeLine = before.find((line) => line.includes(label));
+			const afterLine = after.find((line) => line.includes(label));
+			expect(beforeLine).toBeDefined();
+			expect(afterLine).toBeDefined();
+			expect(beforeLine?.indexOf(label === "Preset" ? "editorial" : "comfortable")).toBe(
+				afterLine?.indexOf(label === "Preset" ? "editorial" : "comfortable"),
+			);
+			expect(beforeLine?.indexOf("product")).toBe(afterLine?.indexOf("product"));
+		}
+	});
 
 	it("uses stacked panels narrowly and equal-bottom side-by-side panels widely", () => {
 		const h = harness();

--- a/tests/settings-workspace.test.ts
+++ b/tests/settings-workspace.test.ts
@@ -138,7 +138,7 @@ describe("Display Settings Workspace", () => {
 		},
 	);
 
-	it("shows layout-order provenance with effective values", () => {
+	it("shows provenance without repeating the complete layout", () => {
 		const h = harness({
 			user: {
 				density: "compact",
@@ -146,38 +146,27 @@ describe("Display Settings Workspace", () => {
 			},
 		});
 		const rendered = text(h.component);
-		expect(rendered).toContain("Density    compact      user");
-		expect(rendered).toContain("Order      user");
-		expect(rendered.indexOf("brand        hidden")).toBeLessThan(rendered.indexOf("activity     shown"));
-		expect(rendered.indexOf("activity     shown")).toBeLessThan(rendered.indexOf("metrics      required"));
+		expect(rendered).toContain("Density      compact       user");
+		expect(rendered).toContain("order:user");
+		expect(rendered).not.toContain("brand › activity");
+		expect(rendered.indexOf("1  ○ brand")).toBeLessThan(rendered.indexOf("2  ● activity"));
+		expect(rendered.indexOf("2  ● activity")).toBeLessThan(rendered.indexOf("3  ◆ metrics"));
 	});
 
-	it.each([40, 80, 120])(
-		"uses real footer rendering to expose every enabled Segment at %s columns",
-		(width) => {
-			const h = harness({
-				user: {
-					segmentLayout: DEFAULT_CONFIG.segmentLayout.map((entry) => ({ ...entry, visible: true })),
-				},
-			});
-			const lines = h.component.render(width);
-			const rendered = lines.join("\n");
-			expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
-			for (const evidence of [
-				"brand        ATELIER",
-				"activity     ● CRAFTING",
-				"performance  TTFT 680ms",
-				"context      ctx 25.0% (auto)",
-				"model        artisan-1 · high",
-				"git          feat/settings*",
-				"statuses     SYNC",
-				"menu         ⌥A",
-			]) {
-				expect(rendered).toContain(evidence);
-			}
-			expect(rendered).toMatch(/metrics\s+.*cache 72%/);
-		},
-	);
+	it.each([40, 80, 120])("uses one real responsive Status Rail preview at %s columns", (width) => {
+		const h = harness({
+			user: {
+				segmentLayout: DEFAULT_CONFIG.segmentLayout.map((entry) => ({ ...entry, visible: true })),
+			},
+		});
+		const lines = h.component.render(width);
+		const previewStart = lines.findIndex((line) => line.includes(" Preview "));
+		expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+		expect(previewStart).toBeGreaterThan(0);
+		expect(lines[previewStart + 1]).toContain("CRAFTING");
+		expect(lines[previewStart + 2]).toContain("└");
+		expect(lines.join("\n")).not.toContain("brand        ATELIER");
+	});
 
 	it("keeps value and provenance columns fixed while focus moves", () => {
 		const h = harness();
@@ -200,10 +189,10 @@ describe("Display Settings Workspace", () => {
 		const h = harness();
 		const narrow = h.component.render(40);
 		expect(narrow.findIndex((line) => line.includes(" Display "))).toBeLessThan(
-			narrow.findIndex((line) => line.includes(" Segments ")),
+			narrow.findIndex((line) => line.includes(" Segment Editor ")),
 		);
 		const wide = h.component.render(120);
-		const sideBySide = wide.find((line) => line.includes(" Display ") && line.includes(" Segments "));
+		const sideBySide = wide.find((line) => line.includes(" Display ") && line.includes(" Segment Editor "));
 		expect(sideBySide).toBeDefined();
 		expect(wide.some((line) => (line.match(/└/g) ?? []).length === 2)).toBe(true);
 	});

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -202,6 +202,41 @@ describe("AtelierRuntime", () => {
 		expect(requestRender).toHaveBeenCalledTimes(2);
 	});
 
+	it("recomputes Session Display patches from retained lower layers with provenance", () => {
+		const requestRender = vi.fn();
+		const runtime = new AtelierRuntime({
+			pi: { exec: vi.fn() } as never,
+			ctx: {
+				modelRegistry: { isUsingOAuth: vi.fn() },
+				getContextUsage: vi.fn(),
+				sessionManager: { getEntries: vi.fn().mockReturnValue([]) },
+			} as never,
+			config: DEFAULT_CONFIG,
+			displayLayers: { user: { density: "compact" } },
+			autoCompact: null,
+			requestRender,
+		});
+		requestRender.mockClear();
+
+		runtime.setSessionDisplayPatch({
+			segmentLayout: DEFAULT_CONFIG.segmentLayout.map((entry) =>
+				entry.id === "performance" ? { ...entry, visible: true } : { ...entry },
+			),
+		});
+
+		expect(runtime.getDisplaySettings()).toMatchObject({ preset: "custom", density: "compact" });
+		expect(runtime.getDisplaySettings().segmentLayout[3]).toEqual({ id: "performance", visible: true });
+		expect(runtime.getDisplayProvenance()).toMatchObject({ density: "user", order: "session" });
+		expect(runtime.getDisplayProvenance().visibility.performance).toBe("session");
+		expect(requestRender).toHaveBeenCalledOnce();
+
+		runtime.setSessionDisplayPatch(undefined);
+		expect(runtime.getDisplaySettings()).toMatchObject({ density: "compact" });
+		expect(runtime.getDisplaySettings().segmentLayout[3]).toEqual({ id: "performance", visible: false });
+		expect(runtime.getDisplayProvenance()).toMatchObject({ density: "user", order: "product" });
+		expect(requestRender).toHaveBeenCalledTimes(2);
+	});
+
 	it("selects again for the next work cycle and still updates configuration", () => {
 		const random = vi.fn().mockReturnValueOnce(0).mockReturnValueOnce(0.999_999);
 		const { runtime, requestRender } = createRuntime(undefined, random);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -237,6 +237,40 @@ describe("AtelierRuntime", () => {
 		expect(requestRender).toHaveBeenCalledTimes(2);
 	});
 
+	it("snapshots and replaces raw Session Display overrides without aliasing", () => {
+		const { runtime } = createRuntime();
+		runtime.replaceSessionDisplayOverride({
+			density: "compact",
+			segmentLayout: DEFAULT_CONFIG.segmentLayout,
+		});
+		const snapshot = runtime.getSessionDisplayOverride();
+		expect(snapshot).toMatchObject({ density: "compact" });
+		if (snapshot?.segmentLayout) snapshot.segmentLayout[0]!.visible = true;
+		expect(runtime.getSessionDisplayOverride()?.segmentLayout?.[0]?.visible).toBe(false);
+		runtime.clearSessionDisplayOverride();
+		expect(runtime.getSessionDisplayOverride()).toBeUndefined();
+	});
+
+	it("recomputes trusted Project precedence after a successful User Display save", () => {
+		const requestRender = vi.fn();
+		const runtime = new AtelierRuntime({
+			pi: { exec: vi.fn() } as never,
+			ctx: {
+				modelRegistry: { isUsingOAuth: vi.fn() },
+				getContextUsage: vi.fn(),
+				sessionManager: { getEntries: vi.fn().mockReturnValue([]) },
+			} as never,
+			config: DEFAULT_CONFIG,
+			displayLayers: { project: { density: "comfortable" } },
+			autoCompact: null,
+			requestRender,
+		});
+		runtime.applySavedUserDisplayPatch({ density: "compact" });
+		expect(runtime.getDisplaySettings().density).toBe("comfortable");
+		expect(runtime.getDisplayProvenance().density).toBe("project");
+		expect(runtime.getSessionDisplayOverride()).toBeUndefined();
+	});
+
 	it("selects again for the next work cycle and still updates configuration", () => {
 		const random = vi.fn().mockReturnValueOnce(0).mockReturnValueOnce(0.999_999);
 		const { runtime, requestRender } = createRuntime(undefined, random);


### PR DESCRIPTION
## Summary

- normalize Display configuration into one provenance-aware Segment layout with legacy compatibility
- add the responsive live Display Settings Workspace with real Status Rail preview and continuous editing
- add one-step Undo, Revert, Display-only User-default Save, and provenance recomputation
- partition `/atelier` and `alt+a` into Settings, Controls, and Actions
- preserve existing explicit Sidebar and enable/disable command behavior
- update documentation, release notes, package verification, and public-seam coverage

## Validation

- `npm run check`
- 15 test files, 316 tests
- responsive geometry coverage at 40, 80, and 120 columns
- manual TUI review with only the local Atelier extension loaded

Closes #6
Closes #7
Closes #8
Closes #9
Closes #10
Closes #11
