### PR TITLE
3 changes

### DIFF
--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -86,6 +86,7 @@ export default function atelierExtension(
 		const sessionName = ctx.sessionManager.getSessionName();
 		const sessionFile = ctx.sessionManager.getSessionFile();
 		const activeTools = pi.getActiveTools();
+		const skillsCount = pi.getCommands().filter((cmd) => cmd.source === "skill").length;
 		return buildSidebarSnapshot({
 			state: targetRuntime.getState(),
 			cwd: ctx.cwd,
@@ -95,6 +96,7 @@ export default function atelierExtension(
 			activeToolCount: activeTools.length,
 			availableToolCount: pi.getAllTools().length,
 			activeToolNames: activeTools,
+			skillsCount,
 			extensionStatuses,
 			...(targetRunActivity ? { runActivity: targetRunActivity.getSnapshot() } : {}),
 		});
@@ -178,6 +180,7 @@ export default function atelierExtension(
 				toggle: () => targetSidebar.toggle(),
 				isToolListExpanded: () => targetRuntime.getConfig().showSidebarToolNames,
 				toggleToolList: async () => setSidebarToolNames(ctx, undefined, targetRuntime, targetSidebar),
+				requestRender: () => targetSidebar.requestRender(),
 			},
 			requestAllRenders,
 			lifecycleGuardedSavePatch(targetRuntime),
@@ -291,6 +294,20 @@ export default function atelierExtension(
 						return;
 					}
 					await setSidebarToolNames(ctx, toolAction === undefined ? undefined : toolAction === "on");
+					return;
+				}
+				if (sidebarAction === "agent") {
+					const [agentAction, ...agentExtra] = extra;
+					if (
+						agentExtra.length > 0 ||
+						(agentAction !== undefined && agentAction !== "on" && agentAction !== "off")
+					) {
+						ctx.ui.notify("Usage: /atelier sidebar agent [on|off]", "warning");
+						return;
+					}
+					const next = agentAction === undefined ? undefined : agentAction === "on";
+					runtime.setConfig({ ...runtime.getConfig(), showSidebarAgent: next ?? !runtime.getConfig().showSidebarAgent });
+					sidebar.requestRender();
 					return;
 				}
 				if (

--- a/src/config.ts
+++ b/src/config.ts
@@ -285,7 +285,13 @@ function applyNonDisplay(input: unknown, config: AtelierConfig, warnings: string
 			config.currencyDecimals = input.currencyDecimals;
 		else warnings.push("currencyDecimals must be an integer from 0 through 6");
 	}
-	for (const key of ["showSessionActions", "showSidebarToolNames", "completionNotifications"] as const) {
+	for (const key of [
+		"showExtensionStatuses",
+		"showSessionActions",
+		"showSidebarToolNames",
+		"showSidebarAgent",
+		"completionNotifications",
+	] as const) {
 		if (typeof input[key] === "boolean") config[key] = input[key];
 		else if (key in input) warnings.push(`${key} must be boolean`);
 	}

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -27,6 +27,7 @@ export interface SidebarControls {
 	toggle(): void;
 	isToolListExpanded(): boolean;
 	toggleToolList(): Promise<void>;
+	requestRender?(): void;
 }
 
 interface MenuTheme {
@@ -468,5 +469,146 @@ export async function openAtelierMenu(
 	_save: SaveConfig = saveUserConfig,
 	savePatch: SaveConfigPatch = saveUserConfigPatch,
 ): Promise<void> {
-	await openAtelierControlCenter(pi, ctx, runtime, userConfigPath, sidebar, () => undefined, savePatch);
+	if (ctx.mode !== "tui") {
+		ctx.ui.notify("Pi Atelier menu requires TUI mode", "warning");
+		return;
+	}
+	const actions = createMenuActions(pi, ctx, runtime, userConfigPath, save, savePatch);
+	for (;;) {
+		const sidebarVisible = sidebar.isVisible();
+		const toolListExpanded = sidebar.isToolListExpanded();
+		const agentPanelVisible = runtime.getConfig().showSidebarAgent;
+		const notificationsEnabled = runtime.getConfig().completionNotifications;
+		const section = await showSelection(ctx, "◆ Pi Atelier", [
+			{
+				value: "sidebar",
+				label: `Sidebar: ${sidebarVisible ? "On" : "Off"}`,
+				description: sidebarVisible ? "Hide the docked information rail" : "Show the docked information rail",
+			},
+			{
+				value: "sidebar-agent",
+				label: `Agent panel: ${agentPanelVisible ? "On" : "Off"}`,
+				description: agentPanelVisible
+					? "Hide the AGENT panel in sidebar"
+					: "Show the AGENT panel in sidebar",
+			},
+			{
+				value: "sidebar-tools",
+				label: `Tool list: ${toolListExpanded ? "Expanded" : "Collapsed"}`,
+				description: toolListExpanded
+					? "Collapse sidebar tool names"
+					: "Show active tool names in the sidebar",
+			},
+			{
+				value: "notifications",
+				label: `Completion notifications: ${notificationsEnabled ? "On" : "Off"}`,
+				description: "Notify when a turn settles or Pi requests input",
+			},
+			{ value: "model", label: "Model", description: "Model and thinking level" },
+			{ value: "tools", label: "Tools", description: "Search and toggle active tools" },
+			{ value: "display", label: "Display", description: "Preset and footer segments" },
+			{ value: "session", label: "Session", description: "Details, name, and compaction" },
+			{ value: "close", label: "Close" },
+		]);
+		if (!section || section === "close") return;
+
+		if (section === "sidebar") {
+			sidebar.toggle();
+			continue;
+		}
+		if (section === "sidebar-agent") {
+			runtime.setConfig({ ...runtime.getConfig(), showSidebarAgent: !agentPanelVisible });
+			try {
+				await savePatch(userConfigPath, { showSidebarAgent: !agentPanelVisible });
+				ctx.ui.notify(`Agent panel ${!agentPanelVisible ? "enabled" : "disabled"}`, "info");
+			} catch (error) {
+				ctx.ui.notify(
+					`Agent panel changed for this session but could not be saved: ${error instanceof Error ? error.message : String(error)}`,
+					"warning",
+				);
+			}
+			sidebar.requestRender?.();
+			continue;
+		}
+		if (section === "sidebar-tools") {
+			await sidebar.toggleToolList();
+			continue;
+		}
+		if (section === "notifications") {
+			await actions.setCompletionNotifications(!notificationsEnabled);
+			continue;
+		}
+
+		if (section === "model") {
+			const action = await ctx.ui.select("Model controls", ["Choose model", "Thinking level", "Back"]);
+			if (action === "Choose model") {
+				const models = ctx.modelRegistry.getAvailable();
+				const labels = models.map((model) => `${model.provider}/${model.id}`);
+				const selected = await ctx.ui.select("Choose model", labels);
+				const model = models[labels.indexOf(selected ?? "")];
+				if (model) await actions.selectModel(model);
+			} else if (action === "Thinking level") {
+				const selected = await ctx.ui.select("Thinking level", [
+					"off",
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max",
+				]);
+				if (selected) actions.setThinkingLevel(selected as Parameters<ExtensionAPI["setThinkingLevel"]>[0]);
+			}
+		} else if (section === "tools") {
+			await showToolSettings(ctx, pi, actions.setTools);
+		} else if (section === "display") {
+			const action = await ctx.ui.select("Display controls", [
+				"Editorial preset",
+				"Minimal preset",
+				"Classic preset",
+				"Toggle segments",
+				"Reorder segments",
+				"Density",
+				"Ornament",
+				"Save as user default",
+				"Back",
+			]);
+			if (action?.endsWith("preset")) actions.setPreset(action.split(" ")[0]?.toLowerCase() as PresetName);
+			else if (action === "Toggle segments") {
+				const current = runtime.getConfig().segments;
+				const optional: SegmentId[] = ["brand", "activity", "model", "git", "statuses", "menu"];
+				const labels = optional.map((id) => `${current.includes(id) ? "✓" : "○"} ${id}`);
+				const selected = await ctx.ui.select("Toggle footer segment", labels);
+				const id = optional[labels.indexOf(selected ?? "")];
+				if (id)
+					actions.setSegments(
+						current.includes(id) ? current.filter((item) => item !== id) : [...current, id],
+					);
+			} else if (action === "Reorder segments") {
+				const current = runtime.getConfig().segments;
+				const selected = await ctx.ui.select("Choose segment", current);
+				if (selected) {
+					const direction = await ctx.ui.select("Move segment", ["earlier", "later"]);
+					if (direction) actions.moveSegment(selected as SegmentId, direction as "earlier" | "later");
+				}
+			} else if (action === "Density") {
+				const density = await ctx.ui.select("Footer density", ["comfortable", "compact"]);
+				if (density) actions.setDensity(density as AtelierConfig["density"]);
+			} else if (action === "Ornament") {
+				const ornament = await ctx.ui.select("Footer ornament", ["restrained", "none"]);
+				if (ornament) actions.setOrnament(ornament as AtelierConfig["ornament"]);
+			} else if (action === "Save as user default") await actions.saveDisplayDefaults();
+		} else if (section === "session") {
+			const options = runtime.getConfig().showSessionActions
+				? ["Show details", "Rename session", "Compact session", "Back"]
+				: ["Show details", "Back"];
+			const action = await ctx.ui.select("Session controls", options);
+			if (action === "Show details") {
+				const file = ctx.sessionManager.getSessionFile();
+				ctx.ui.notify(file ? `Session: ${file}` : "Ephemeral session", "info");
+			} else if (action === "Rename session") await actions.renameSession();
+			else if (action === "Compact session") await actions.compactSession();
+		}
+	}
+	}
 }

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -24,6 +24,7 @@ export interface SidebarSnapshotInput {
 	branchEntryCount: number;
 	activeToolCount: number;
 	availableToolCount: number;
+	skillsCount: number;
 	activeToolNames?: readonly string[];
 	extensionStatuses: readonly string[];
 	runActivity?: RunActivitySnapshot;
@@ -38,6 +39,7 @@ export interface SidebarSnapshot extends AtelierState {
 	branchEntryCount: number;
 	activeToolCount: number;
 	availableToolCount: number;
+	skillsCount: number;
 	activeToolNames: readonly string[];
 	runActivity: RunActivitySnapshot;
 }
@@ -59,6 +61,7 @@ export function buildSidebarSnapshot(input: SidebarSnapshotInput): SidebarSnapsh
 		branchEntryCount: input.branchEntryCount,
 		activeToolCount: input.activeToolCount,
 		availableToolCount: input.availableToolCount,
+		skillsCount: input.skillsCount,
 		activeToolNames: [...new Set((input.activeToolNames ?? []).map(sanitize).filter(Boolean))].sort((a, b) =>
 			a.localeCompare(b, "en"),
 		),
@@ -448,7 +451,7 @@ function usageRows(
 			),
 		);
 	}
-	if (metrics.costAvailable) {
+	if (metrics.costAvailable && metrics.cost > 0) {
 		const cost = `$${Math.max(0, Number.isFinite(metrics.cost) ? metrics.cost : 0).toFixed(
 			currencyDecimals(config.currencyDecimals),
 		)}`;
@@ -464,7 +467,7 @@ function toolsStatusRows(
 	palette: AtelierPalette,
 ): string[] {
 	const disclosure = showToolNames ? "▾" : "▸";
-	return [
+	const rows = [
 		spacedRow(
 			palette.paint(
 				"primary",
@@ -474,6 +477,10 @@ function toolsStatusRows(
 			contentWidth,
 		),
 	];
+	if (finiteCount(snapshot.skillsCount) > 0) {
+		rows.push(spacedRow(palette.paint("primary", `${finiteCount(snapshot.skillsCount)} skills`), "", contentWidth));
+	}
+	return rows;
 }
 
 function activeToolNameRows(
@@ -778,16 +785,20 @@ export function renderSidebarLines(
 						dropRank: Number.POSITIVE_INFINITY,
 					},
 				]
+		: []),
+		...(config.showSidebarAgent
+			? [
+					{
+						name: "agent",
+						panel: "AGENT",
+						panelRole: activityRole(snapshot.activity),
+						panelJewel: (snapshot.activity === "working" && Math.floor(now / 400) % 2 === 1 ? "✧" : "✦") as "✦" | "✧",
+						rows: agentRows(snapshot, layout, panelContentWidth, palette, theme),
+						required: true,
+						dropRank: Number.POSITIVE_INFINITY,
+					},
+				]
 			: []),
-		{
-			name: "agent",
-			panel: "AGENT",
-			panelRole: activityRole(snapshot.activity),
-			panelJewel: snapshot.activity === "working" && Math.floor(now / 400) % 2 === 1 ? "✧" : "✦",
-			rows: agentRows(snapshot, layout, panelContentWidth, palette, theme),
-			required: true,
-			dropRank: Number.POSITIVE_INFINITY,
-		},
 		...activitySidebarGroups(snapshot, panelContentWidth, palette, now).map((group) => ({
 			...group,
 			required: group.name === "activityCore",

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export interface AtelierConfig extends DisplaySettings {
 	currencyDecimals: number;
 	showSessionActions: boolean;
 	showSidebarToolNames: boolean;
+	showSidebarAgent: boolean;
 	completionNotifications: boolean;
 }
 
@@ -136,5 +137,6 @@ export const DEFAULT_CONFIG: AtelierConfig = {
 	currencyDecimals: 3,
 	showSessionActions: true,
 	showSidebarToolNames: false,
+	showSidebarAgent: true,
 	completionNotifications: true,
 };

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -56,6 +56,7 @@ function harness(mode: "tui" | "print" = "tui", notificationPlatform: NodeJS.Pla
 		getThinkingLevel: vi.fn().mockReturnValue("medium"),
 		getActiveTools: vi.fn().mockReturnValue(["read"]),
 		getAllTools: vi.fn().mockReturnValue([{ name: "read" }]),
+		getCommands: vi.fn().mockReturnValue([]),
 	};
 	const custom = vi.fn((factory: (...args: any[]) => any, options: any): Promise<any> => {
 		const requestRender = vi.fn();

--- a/tests/sidebar.test.ts
+++ b/tests/sidebar.test.ts
@@ -75,6 +75,7 @@ function snapshot() {
 		branchEntryCount: 38,
 		activeToolCount: 8,
 		availableToolCount: 12,
+		skillsCount: 0,
 		extensionStatuses: ["tests passing"],
 		runActivity: EMPTY_RUN_ACTIVITY,
 	});
@@ -148,6 +149,7 @@ describe("sidebar snapshot and layout", () => {
 			branchEntryCount: 38,
 			activeToolCount: 8,
 			availableToolCount: 12,
+			skillsCount: 0,
 		});
 	});
 
@@ -299,6 +301,7 @@ describe("sidebar snapshot and layout", () => {
 			branchEntryCount: 6,
 			activeToolCount: 8,
 			availableToolCount: 12,
+			skillsCount: 0,
 			extensionStatuses: [],
 		});
 		expect(
@@ -407,6 +410,7 @@ describe("sidebar snapshot and layout", () => {
 			branchEntryCount: 6,
 			activeToolCount: 8,
 			availableToolCount: 12,
+			skillsCount: 0,
 			extensionStatuses: [],
 		});
 		const rows = contentRows(renderSidebarLines(missingSession, DEFAULT_CONFIG, theme, 44, 36, false));
@@ -431,6 +435,7 @@ describe("sidebar snapshot and layout", () => {
 			branchEntryCount: 6,
 			activeToolCount: 8,
 			availableToolCount: 12,
+			skillsCount: 0,
 			extensionStatuses: [],
 		});
 		expect(contentRows(renderSidebarLines(persisted, DEFAULT_CONFIG, theme, 44, 36, false))).toContain(
@@ -955,6 +960,7 @@ describe("sidebar snapshot and layout", () => {
 			branchEntryCount: 6,
 			activeToolCount: 3,
 			availableToolCount: 7,
+			skillsCount: 0,
 			activeToolNames: ["read", "\u001b[31mbash", " edit\n", "read", "   "],
 			extensionStatuses: [],
 		});
@@ -997,6 +1003,7 @@ describe("sidebar snapshot and layout", () => {
 			branchEntryCount: 6,
 			activeToolCount: 4,
 			availableToolCount: 7,
+			skillsCount: 0,
 			activeToolNames: ["write", "read", "edit", "bash"],
 			extensionStatuses: [],
 		});
@@ -1018,6 +1025,7 @@ describe("sidebar snapshot and layout", () => {
 			branchEntryCount: 0,
 			activeToolCount: 0,
 			availableToolCount: 7,
+			skillsCount: 0,
 			activeToolNames: [],
 			extensionStatuses: [],
 		});
@@ -1034,6 +1042,7 @@ describe("sidebar snapshot and layout", () => {
 			branchEntryCount: 6,
 			activeToolCount: 8,
 			availableToolCount: 12,
+			skillsCount: 0,
 			extensionStatuses: [],
 		});
 		const rows = contentRows(renderSidebarLines(emptyStatuses, DEFAULT_CONFIG, theme, 44, 36, false));
@@ -1051,6 +1060,7 @@ describe("sidebar snapshot and layout", () => {
 			branchEntryCount: 6,
 			activeToolCount: 8,
 			availableToolCount: 12,
+			skillsCount: 0,
 			extensionStatuses: ["tests \u001b[31mpassing", "api\nready", "sync warning", "index failed", "   "],
 		});
 		const rows = contentRows(renderSidebarLines(statusSnapshot, DEFAULT_CONFIG, theme, 44, 36, false));
@@ -1067,6 +1077,27 @@ describe("sidebar snapshot and layout", () => {
 		expect(rows).toContainEqual(expect.stringMatching(/^8 \/ 12 active\s+▸$/));
 		expect(rows).not.toContain("tests passing");
 		expect(rows).not.toContain("ALERTS");
+	});
+
+	it("shows skills count under TOOLS when active", () => {
+		const withSkills = buildSidebarSnapshot({
+			state: { ...state, extensionStatuses: [] },
+			cwd: "/tmp/project",
+			branchEntryCount: 6,
+			activeToolCount: 3,
+			availableToolCount: 7,
+			skillsCount: 4,
+			extensionStatuses: [],
+		});
+		const rows = contentRows(renderSidebarLines(withSkills, DEFAULT_CONFIG, theme, 44, 36, false));
+		const toolsIndex = rows.indexOf("TOOLS");
+		expect(rows[toolsIndex + 1]).toMatch(/^3 \/ 7 active\s+▸$/);
+		expect(rows[toolsIndex + 2]).toMatch(/^4 skills$/);
+	});
+
+	it("hides skills line when count is zero", () => {
+		const rows = contentRows(renderSidebarLines(snapshot(), DEFAULT_CONFIG, theme, 44, 36, false));
+		expect(rows).not.toContainEqual(expect.stringMatching(/skills$/));
 	});
 
 	it("keeps only the required hierarchy in a compact 12 row rail", () => {
@@ -1097,6 +1128,7 @@ describe("sidebar snapshot and layout", () => {
 			branchEntryCount: 0,
 			activeToolCount: 0,
 			availableToolCount: 0,
+			skillsCount: 0,
 			extensionStatuses: [],
 		});
 		const lines = renderSidebarLines(missing, DEFAULT_CONFIG, theme, 32, 36, false);


### PR DESCRIPTION
- show skills count in tools block
- possible to hide agent block ( i find all this information available in the footer instead, to save space in sidebar)
- hide cost if $0 (my local API provides a cost field, but it is always 0 as i run locally)