### PR TITLE
feat: add global sidebar startup setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add a global **Sidebar on startup** setting that is saved to user configuration while preserving session-scoped Sidebar on/off controls.
+
 ## 0.7.2 — 2026-08-06
 
 - Restore the non-overlapping Sidebar split in both Pi 0.84 renderer modes while retaining the non-capturing overlay as the content and safe fallback seam.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Open Pi Atelier with:
 
 The default shortcut is `alt+a`. Both entry points open the partitioned **Atelier Control Center**:
 
-- **Settings** — the Display Settings Workspace, completion notifications, and sidebar tool-list expansion
+- **Settings** — the Display Settings Workspace, global Sidebar startup preference, completion notifications, and sidebar tool-list expansion
 - **Controls** — session-scoped Sidebar visibility, model/thinking selection, and active tools
 - **Actions** — session details, rename, and safe compaction
 
@@ -126,7 +126,7 @@ Additional commands:
 
 ## Sidebar
 
-The sidebar starts shown whenever the extension initializes. An explicit `off` applies only to the current runtime; `/reload` restores the default shown state. Use these commands to control it explicitly:
+The sidebar starts shown by default whenever the extension initializes. Use **Settings → Sidebar on startup** to change this global user preference; it is saved immediately and applies from the next session or reload. An explicit `on` or `off` still applies only to the current runtime. Use these commands to control it explicitly:
 
 ```text
 /atelier sidebar       # toggle between shown and hidden
@@ -184,7 +184,7 @@ Trusted project configuration:
 <project>/.pi/pi-atelier.json
 ```
 
-Project settings override user settings only after Pi trusts the project. Most menu changes apply to the current session; **Save as user default** writes display configuration atomically. Sidebar tool details and completion notifications are saved immediately so those preferences survive future sessions. Agent visibility and completion notifications are global user preferences, so project and session configuration cannot override them. Pi Atelier never modifies project configuration from the menu.
+Project settings override user settings only after Pi trusts the project. Most menu changes apply to the current session; **Save as user default** writes display configuration atomically. Sidebar startup visibility, Sidebar tool details, and completion notifications are saved immediately so those preferences survive future sessions. Sidebar startup visibility, Agent visibility, and completion notifications are global user preferences, so project and session configuration cannot override them. Pi Atelier never modifies project configuration from the menu.
 
 Complete example:
 
@@ -210,6 +210,7 @@ Complete example:
   "showSessionActions": true,
   "showSidebarToolNames": false,
   "showSidebarAgent": true,
+  "showSidebarOnStartup": true,
   "sidebarPanelLayout": [
     { "id": "agent", "visible": true },
     { "id": "activity", "visible": true },
@@ -232,6 +233,8 @@ Product defaults are layered with **User default**, trusted **Project override**
 Legacy `segments`, `ornament`, and `showExtensionStatuses` keys remain load-compatible and are translated into a complete normalized layout. A usable `segmentLayout` is authoritative over those keys in the same layer. Legacy omitted segments remain present but hidden; legacy Brand and Statuses combinations retain their prior visible result. Brand and Statuses have no overlapping runtime gates: normalized `segmentLayout` is the sole visibility source. New configuration should use `segmentLayout`.
 
 During streaming, TPS is prefixed with `~` while it is estimated, then replaced with final throughput when the response ends. Each value is dimmed to `~` until it is measured. Visibility toggles retain an entry's position, and reordering includes hidden entries.
+
+`showSidebarOnStartup` (default `true`) controls whether a new session opens the Sidebar automatically. It is a global user-only preference; trusted project and session values are ignored. Change it from **Settings → Sidebar on startup**. The `/atelier sidebar on|off` commands remain available for the current runtime regardless of this preference.
 
 `showSidebarAgent` controls whether the Agent panel renders inside the sidebar. It is a global user-only compatibility input; trusted project and session values are ignored. When set to `false`, the sidebar still shows but omits the agent state and model metadata section while leaving Activity, TODOS, Context, Workspace, Usage, and Tools unaffected. Use **Settings → Display** to edit the ordered Sidebar layout.
 

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -643,7 +643,7 @@ export default function atelierExtension(
 			}
 			if (enabled && isFresh()) {
 				installFooter(initializationContext, candidateRuntime, localRunActivity, initializationGeneration);
-				localSidebar.show();
+				if (loaded.config.showSidebarOnStartup) localSidebar.show();
 			}
 			void candidateRuntime.refreshWorkspacePulse();
 		} catch (error) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -363,6 +363,7 @@ function applyNonDisplay(input: unknown, config: AtelierConfig, warnings: string
 		"showSidebarToolNames",
 		"showSidebarAgent",
 		"showSidebarTodos",
+		"showSidebarOnStartup",
 		"completionNotifications",
 	] as const) {
 		if (typeof input[key] === "boolean") config[key] = input[key];
@@ -418,6 +419,9 @@ export function mergeConfig(...inputs: unknown[]): ConfigLoadResult {
 	const resolved = resolveDisplayLayers(displayLayers);
 	const sidebar = resolveSidebarLayout(displayLayers);
 	Object.assign(config, resolved.display, { sidebarPanelLayout: cloneSidebarLayout(sidebar.layout) });
+	const global = cloneConfig(DEFAULT_CONFIG);
+	applyNonDisplay(inputs[0], global, []);
+	config.showSidebarOnStartup = global.showSidebarOnStartup;
 	if (sidebar.authoritative) {
 		config.showSidebarAgent =
 			sidebar.layout.find((entry) => entry.id === "agent")?.visible ?? config.showSidebarAgent;
@@ -466,9 +470,10 @@ export async function loadConfig(options: LoadConfigOptions): Promise<ConfigLoad
 		config.showSidebarTodos =
 			sidebar.layout.find((entry) => entry.id === "todos")?.visible ?? config.showSidebarTodos;
 	}
-	// Completion notifications and legacy Sidebar visibility are global-user-only.
+	// Startup visibility, completion notifications, and legacy Sidebar visibility are global-user-only.
 	const global = cloneConfig(DEFAULT_CONFIG);
 	applyNonDisplay(user.value, global, []);
+	config.showSidebarOnStartup = global.showSidebarOnStartup;
 	config.completionNotifications = global.completionNotifications;
 	if (!sidebar.authoritative) applyGlobalSidebarCompatibility(config, user.value);
 	return {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -134,6 +134,22 @@ export function createMenuActions(
 				),
 			});
 		},
+		async setShowSidebarOnStartup(enabled: boolean): Promise<void> {
+			const previous = runtime.getConfig();
+			runtime.setConfig({ ...previous, showSidebarOnStartup: enabled });
+			try {
+				await savePatch(userConfigPath, { showSidebarOnStartup: enabled });
+				ctx.ui.notify(`Sidebar will start ${enabled ? "shown" : "hidden"}`, "info");
+			} catch (error) {
+				runtime.setConfig(previous);
+				ctx.ui.notify(
+					`Sidebar startup preference could not be saved: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+					"warning",
+				);
+			}
+		},
 		async setCompletionNotifications(enabled: boolean): Promise<void> {
 			runtime.setConfig({ ...runtime.getConfig(), completionNotifications: enabled });
 			try {
@@ -382,6 +398,11 @@ export async function openAtelierControlCenter(
 						description: "Session overrides, preview, Undo, Revert, and Save",
 					},
 					{
+						value: "sidebar-startup",
+						label: `Sidebar on startup: ${runtime.getConfig().showSidebarOnStartup ? "On" : "Off"}`,
+						description: "Global user preference",
+					},
+					{
 						value: "notifications",
 						label: `Completion notifications: ${runtime.getConfig().completionNotifications ? "On" : "Off"}`,
 						description: "User preference",
@@ -421,6 +442,8 @@ export async function openAtelierControlCenter(
 						requestAllRenders,
 						savePatch,
 					);
+				else if (choice === "sidebar-startup")
+					await actions.setShowSidebarOnStartup(!runtime.getConfig().showSidebarOnStartup);
 				else if (choice === "notifications")
 					await actions.setCompletionNotifications(!runtime.getConfig().completionNotifications);
 				else await sidebar.toggleToolList();

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,7 @@ export interface AtelierConfig extends DisplaySettings {
 	showSidebarToolNames: boolean;
 	showSidebarAgent: boolean;
 	showSidebarTodos: boolean;
+	showSidebarOnStartup: boolean;
 	sidebarPanelLayout: SidebarPanelLayout;
 	completionNotifications: boolean;
 }
@@ -175,6 +176,7 @@ export const DEFAULT_CONFIG: AtelierConfig = {
 	showSidebarToolNames: false,
 	showSidebarAgent: true,
 	showSidebarTodos: true,
+	showSidebarOnStartup: true,
 	sidebarPanelLayout: [
 		{ id: "agent", visible: true },
 		{ id: "activity", visible: true },

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -315,6 +315,34 @@ describe("configuration", () => {
 		);
 	});
 
+	it("loads the global Sidebar startup preference only from user config", async () => {
+		await writeJson(userPath, { showSidebarOnStartup: false });
+		await writeJson(projectPath, { showSidebarOnStartup: true });
+
+		const result = await loadConfig({
+			userPath,
+			projectPath,
+			projectTrusted: true,
+			session: { showSidebarOnStartup: true },
+		});
+
+		expect(result.config.showSidebarOnStartup).toBe(false);
+	});
+
+	it("keeps the Sidebar startup preference global when merging config layers", () => {
+		expect(
+			mergeConfig(
+				{ showSidebarOnStartup: false },
+				{ showSidebarOnStartup: true },
+				{ showSidebarOnStartup: true },
+			).config.showSidebarOnStartup,
+		).toBe(false);
+		expect(validateConfig({ showSidebarOnStartup: "yes" }).warnings).toContain(
+			"showSidebarOnStartup must be boolean",
+		);
+		expect(DEFAULT_CONFIG.showSidebarOnStartup).toBe(true);
+	});
+
 	it("loads persisted showSidebarAgent false from user config", async () => {
 		await writeJson(userPath, { showSidebarAgent: false });
 		const result = await loadConfig({ userPath, projectPath, projectTrusted: false });

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -276,6 +276,19 @@ describe("extension registration", () => {
 		expect(h.setFooter).not.toHaveBeenCalled();
 	});
 
+	it("starts with the Sidebar hidden when the global preference is off", async () => {
+		await withPersistedUserConfig({ showSidebarOnStartup: false }, async () => {
+			const h = harness();
+
+			await start(h);
+
+			expect(h.overlays).toHaveLength(0);
+			expect(h.setFooter).toHaveBeenCalledOnce();
+			await command(h, "sidebar on");
+			expect(h.overlays).toHaveLength(1);
+		});
+	});
+
 	it("starts enabled and toggles the persistent sidebar on -> off -> on", async () => {
 		const h = harness();
 		await start(h);

--- a/tests/menu.test.ts
+++ b/tests/menu.test.ts
@@ -144,7 +144,13 @@ describe("Control Center presentation", () => {
 	it.each([
 		[
 			"settings",
-			["Display: editorial", "Completion notifications: On", "Sidebar tool list: Collapsed", "Back"],
+			[
+				"Display: editorial",
+				"Sidebar on startup: On",
+				"Completion notifications: On",
+				"Sidebar tool list: Collapsed",
+				"Back",
+			],
 		],
 		["actions", ["Session details", "Rename session", "Compact session", "Back"]],
 	] as const)("routes the %s root category to its destination", async (category, expectedLabels) => {
@@ -163,6 +169,30 @@ describe("Control Center presentation", () => {
 			sidebar,
 		);
 		expect(rootMenuItems[1]?.map((item) => item.label)).toEqual(expectedLabels);
+	});
+
+	it("toggles and persists Sidebar startup from Settings", async () => {
+		rootMenuItems.length = 0;
+		const h = harness();
+		const sidebar: SidebarControls = {
+			isVisible: vi.fn(() => true),
+			toggle: vi.fn(),
+			isToolListExpanded: vi.fn(() => false),
+			toggleToolList: vi.fn().mockResolvedValue(undefined),
+		};
+
+		await openAtelierControlCenter(
+			h.pi as never,
+			contextWithSelections(["settings", "sidebar-startup", "back", "close"]) as never,
+			h.runtime as never,
+			"/tmp/user.json",
+			sidebar,
+			undefined,
+			h.savePatch,
+		);
+
+		expect(h.runtime.getConfig().showSidebarOnStartup).toBe(false);
+		expect(h.savePatch).toHaveBeenCalledWith("/tmp/user.json", { showSidebarOnStartup: false });
 	});
 
 	it("routes Control Center Settings → Display to the workspace", async () => {
@@ -319,6 +349,16 @@ describe("menu actions", () => {
 		const h = harness();
 		h.actions.setTools(["read", "missing"]);
 		expect(h.pi.setActiveTools).toHaveBeenCalledWith(["read"]);
+	});
+
+	it("persists the global Sidebar startup preference", async () => {
+		const h = harness();
+
+		await h.actions.setShowSidebarOnStartup(false);
+
+		expect(h.runtime.getConfig().showSidebarOnStartup).toBe(false);
+		expect(h.savePatch).toHaveBeenCalledWith("/tmp/user.json", { showSidebarOnStartup: false });
+		expect(h.ctx.ui.notify).toHaveBeenCalledWith("Sidebar will start hidden", "info");
 	});
 
 	it("persists only completion notifications while display changes remain session-scoped", async () => {


### PR DESCRIPTION
## Summary

Adds a global `showSidebarOnStartup` preference, exposed directly in Atelier's Settings menu.

- defaults to `true`, preserving existing behavior;
- persists immediately to user configuration;
- ignores trusted-project and session overrides;
- applies on the next session start or reload;
- keeps `/atelier sidebar on|off` available for the current runtime.

This is the maintainer implementation of the focused behavior proposed in #23, with positive naming and Settings integration so users do not need to edit JSON manually.

## Validation

- `npm run check` — passed
  - typecheck
  - Biome lint and format check
  - 15 test files / 407 tests
  - package-content verification
- `git diff --check` — passed
- Maintainer local TUI validation — Settings toggle persisted; reload respected hidden/shown startup state; `/atelier sidebar on` remained available while startup was disabled.

## Documentation

Updated README configuration, Sidebar instructions, Settings description, and the Unreleased changelog.

## Release safety

Does not publish, change versions, create tags/releases, or modify publishing credentials.
