### PR TITLE
Fix fullscreen mouse scrolling after sidebar changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Preserve fullscreen transcript mouse-wheel scrolling after Sidebar resize and visibility changes by leaving Pi's persistent mouse reporting enabled.
+
 ## 0.8.0 — 2026-08-07
 
 - Add a global **Sidebar on startup** setting that is saved to user configuration while preserving session-scoped Sidebar on/off controls.

--- a/src/split-pane.ts
+++ b/src/split-pane.ts
@@ -1,5 +1,5 @@
-import { HStack, matchesKey } from "@earendil-works/pi-tui";
 import type { Component, OverlayOptions, TUI } from "@earendil-works/pi-tui";
+import { HStack, matchesKey } from "@earendil-works/pi-tui";
 
 const ENABLE_MOUSE = "\u001b[?1002h\u001b[?1006h";
 const DISABLE_MOUSE = "\u001b[?1006l\u001b[?1002l";
@@ -105,7 +105,7 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 	let resizeStartWidth = sidebarWidth;
 	let dragging = false;
 	let unsubscribeInput: (() => void) | undefined;
-	let mouseReportingEnabled = false;
+	let resizeMouseTerminal: TUI["terminal"] | undefined;
 	let controller: SplitPaneController;
 	const adapterOwner = {};
 
@@ -199,12 +199,16 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 		adaptedTui[PI_084_FULLSCREEN_LAYOUT_ADAPTER] = undefined;
 	};
 
+	const isPiFullscreenRenderer = (): boolean => {
+		if (!tui || tui.mode !== "fullscreen") return false;
+		const prototype = Object.getPrototypeOf(tui) as { constructor?: { name?: string } } | null;
+		return prototype?.constructor?.name === "TuiAltScreen";
+	};
+
 	const prioritizeFullscreenResizeInput = (
 		handler: (data: string) => { consume?: boolean; data?: string } | undefined,
 	) => {
-		if (!tui || tui.mode !== "fullscreen") return;
-		const prototype = Object.getPrototypeOf(tui) as { constructor?: { name?: string } } | null;
-		if (prototype?.constructor?.name !== "TuiAltScreen") return;
+		if (!isPiFullscreenRenderer()) return;
 		const listeners = (tui as unknown as { inputListeners?: Set<typeof handler> }).inputListeners;
 		if (!(listeners instanceof Set) || !listeners.delete(handler)) return;
 		// Pi 0.84's viewport listener consumes every mouse event for text selection.
@@ -256,17 +260,17 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 	const requestRender = () => tui?.requestRender();
 
 	const stopResize = (restore: boolean) => {
-		if (!resizing && !mouseReportingEnabled && !unsubscribeInput) return;
+		if (!resizing && !resizeMouseTerminal && !unsubscribeInput) return;
 		if (restore) sidebarWidth = resizeStartWidth;
 		syncOverlayWidth();
 		syncFullscreenLayoutAdapter();
-		const shouldDisableMouse = mouseReportingEnabled;
+		const mouseTerminal = resizeMouseTerminal;
 		const unsubscribe = unsubscribeInput;
 		dragging = false;
 		resizing = false;
-		mouseReportingEnabled = false;
+		resizeMouseTerminal = undefined;
 		unsubscribeInput = undefined;
-		if (shouldDisableMouse) safely(() => tui?.terminal.write(DISABLE_MOUSE));
+		if (mouseTerminal) safely(() => mouseTerminal.write(DISABLE_MOUSE));
 		if (unsubscribe) safely(unsubscribe);
 		safely(() => options.onResizeChange?.(false));
 		safely(requestRender);
@@ -391,8 +395,8 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 			try {
 				unsubscribeInput = options.subscribeInput(handleResizeInput);
 				prioritizeFullscreenResizeInput(handleResizeInput);
-				mouseReportingEnabled = true;
-				tui.terminal.write(ENABLE_MOUSE);
+				resizeMouseTerminal = isPiFullscreenRenderer() ? undefined : tui.terminal;
+				resizeMouseTerminal?.write(ENABLE_MOUSE);
 				options.onResizeChange?.(true);
 				requestRender();
 				return true;

--- a/tests/split-pane.test.ts
+++ b/tests/split-pane.test.ts
@@ -1,12 +1,12 @@
-import { TuiAltScreen, TuiMainScreen as PiTuiMainScreen } from "@earendil-works/pi-tui";
 import type { TUI } from "@earendil-works/pi-tui";
+import { TuiMainScreen as PiTuiMainScreen, TuiAltScreen } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
 import {
+	createSplitPaneController,
 	DEFAULT_SIDEBAR_WIDTH,
 	MAX_SIDEBAR_WIDTH,
 	MIN_MAIN_WIDTH,
 	MIN_SIDEBAR_WIDTH,
-	createSplitPaneController,
 	parseSgrMouseEvent,
 } from "../src/split-pane.js";
 
@@ -139,6 +139,84 @@ describe("temporary Resize mode", () => {
 		expect(split.isResizing()).toBe(false);
 		expect(listeners.size).toBe(1);
 	});
+	it("keeps fullscreen transcript wheel scrolling after Resize and sidebar visibility changes", () => {
+		let deliverInput: ((data: string) => void) | undefined;
+		let mouseReporting = false;
+		const terminal = {
+			columns: 120,
+			rows: 8,
+			write: vi.fn((data: string) => {
+				if (data.includes("\u001b[?1006h")) mouseReporting = true;
+				if (data.includes("\u001b[?1006l")) mouseReporting = false;
+			}),
+			start: vi.fn((onInput: (data: string) => void) => {
+				deliverInput = onInput;
+			}),
+			stop: vi.fn(),
+			hideCursor: vi.fn(),
+			showCursor: vi.fn(),
+			sendWheelUp() {
+				if (mouseReporting) deliverInput?.("\u001b[<64;1;1M");
+			},
+		};
+		const renderer = new TuiAltScreen(terminal as never);
+		renderer.addChild({
+			render: () => Array.from({ length: 30 }, (_, index) => `line ${index}`),
+			invalidate() {},
+		});
+		renderer.start();
+		renderer.renderNow();
+		const split = createSplitPaneController({
+			subscribeInput: (handler) => renderer.addInputListener(handler),
+		});
+		split.attach(stableTuiReference(() => renderer));
+		split.show();
+
+		expect(split.beginResize()).toBe(true);
+		split.finishResize();
+		split.hide();
+		split.show();
+		renderer.renderNow();
+		const viewportBeforeWheel = renderer.viewportTop;
+		terminal.sendWheelUp();
+
+		expect(renderer.viewportTop).toBe(viewportBeforeWheel - 1);
+		renderer.stop();
+	});
+
+	it("temporarily manages mouse reporting for unsupported fullscreen renderers", () => {
+		const renderer = new FullscreenRenderer();
+		const split = createSplitPaneController({ subscribeInput: () => vi.fn() });
+		split.attach(stableTuiReference(() => renderer as unknown as TUI));
+		split.show();
+
+		expect(split.beginResize()).toBe(true);
+		split.finishResize();
+
+		expect(renderer.terminal.write.mock.calls).toEqual([
+			["\u001b[?1002h\u001b[?1006h"],
+			["\u001b[?1006l\u001b[?1002l"],
+		]);
+	});
+
+	it("cleans mouse reporting on the renderer that entered Resize mode", () => {
+		let renderer: TUI = new TuiMainScreen() as unknown as TUI;
+		const split = createSplitPaneController({ subscribeInput: () => vi.fn() });
+		split.attach(stableTuiReference(() => renderer));
+		split.show();
+
+		expect(split.beginResize()).toBe(true);
+		const resizeRenderer = renderer as unknown as TuiMainScreen;
+		expect(resizeRenderer.terminal.write).toHaveBeenCalledWith("\u001b[?1002h\u001b[?1006h");
+		renderer = new FullscreenRenderer() as unknown as TUI;
+		const fullscreenRenderer = renderer as unknown as FullscreenRenderer;
+
+		split.finishResize();
+
+		expect(resizeRenderer.terminal.write).toHaveBeenLastCalledWith("\u001b[?1006l\u001b[?1002l");
+		expect(fullscreenRenderer.terminal.write).not.toHaveBeenCalled();
+	});
+
 	it("does not start dragging for wheel or non-primary mouse events", () => {
 		const h = resizeHarness();
 		h.split.beginResize();


### PR DESCRIPTION
## Summary

Preserve Pi fullscreen TUI mouse-wheel scrolling after Pi Atelier Sidebar resize and visibility changes.

Pi's fullscreen renderer owns persistent terminal mouse reporting. Resize mode previously wrote a disable sequence when it ended, unintentionally disabling Pi's wheel-event delivery. This change leaves mouse reporting under `TuiAltScreen` ownership while retaining temporary Atelier ownership for regular and fallback renderers.

## Issue and scope

- [x] I linked the issue for this change, when an issue was required.
- [x] This PR contains one coherent change or user-facing behavior.
- [x] Unrelated changes and non-goals are called out below or split into another PR.

**Issue:** Closes #30

**Scope / non-goals:** Fix mouse-reporting ownership during Sidebar Resize and visibility changes. No configuration or layout redesign. Other uncommitted local workflow-file changes are excluded from this PR.

## Validation

- [x] I ran `npm run check` (blocked by pre-existing repository failures described below).
- [x] I ran `git diff --check origin/main...HEAD` against the updated `main`.
- [x] I added or updated regression tests through the relevant public/runtime seam for behavior changes.
- [x] For configuration, event, or sidebar behavior, relevant edge cases are covered or explained below.
- [x] For TUI changes, I manually validated with the repository-local Pi CLI.
- [ ] For TUI changes, I provided a screenshot/recording URL or attached artifact, terminal dimensions/context, and observed result below.

**Commands and results:**

- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npx biome format src/split-pane.ts tests/split-pane.test.ts CHANGELOG.md` — passed.
- `npx vitest run --exclude tests/package.test.ts` — 444/444 passed.
- `npm run check:pack` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `npm run check` — blocked by pre-existing `skills-lock.json` formatting differences. The full test suite also has three pre-existing `tests/package.test.ts` failures because the current README does not contain older contract strings (`28`, `sidebarPanelLayout`, and `Shift+Up/Shift+Down`). These reproduce on `origin/main` and are unrelated to this PR.

**Manual validation:** macOS, Pi 0.84.0, fullscreen TUI. Ran:

```bash
npx --no-install pi --no-extensions --extension . --tui-mode fullscreen
```

After resizing and toggling the Sidebar, the mouse wheel continued scrolling the conversation transcript instead of cycling prompt history. Reporter confirmed the fix succeeded.

**Screenshots / recordings:** Not attached — behavior was manually confirmed in the interactive terminal, but no visual artifact was captured.

## Documentation and compatibility

- [x] I updated `CHANGELOG.md` under `Unreleased`; README usage is unchanged.
- [x] Configuration or documentation impact is described below.
- [x] Known limitations and compatibility considerations are described below.

**Config/docs impact:** No configuration changes. Added an Unreleased changelog entry.

**Known limitations:** The Pi-specific persistent mouse-reporting exemption is intentionally limited to the concrete `TuiAltScreen` renderer. Unsupported fullscreen renderers continue using Atelier's temporary enable/disable lifecycle.

## Release safety

- [x] This PR does not publish packages, change release versions, create tags/releases, or edit npm publishing credentials.
