### PR TITLE
Fix/fullscreen copy safe sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Render the fullscreen Sidebar inside Pi's split layout instead of as a visible overlay so transcript selection and copy exclude Sidebar content.
+- Render the fullscreen Sidebar inside Pi's split layout instead of as a visible overlay so transcript selection and copy exclude Sidebar content; this now requires Pi 0.84.0 or newer.
 - Wait to run Workspace Pulse Git inspections until Pi considers the project trusted.
 
 ## 0.8.2 — 2026-08-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Render the fullscreen Sidebar inside Pi's split layout instead of as a visible overlay so transcript selection and copy exclude Sidebar content.
 - Wait to run Workspace Pulse Git inspections until Pi considers the project trusted.
 
 ## 0.8.2 — 2026-08-19

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thanks for helping improve Pi Atelier. It is an interactive Pi TUI extension, so
 
 ## Set up a checkout
 
-Pi Atelier requires Node.js `22.19.0` or newer, Pi `0.80.7` or newer, and an interactive TUI.
+Pi Atelier requires Node.js `22.19.0` or newer, Pi `0.84.0` or newer, and an interactive TUI.
 
 ```bash
 npm install

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A responsive status rail and activity sidebar for [Pi](https://pi.dev).
 
 ## Requirements
 
-- Pi 0.80.7 or newer
+- Pi 0.84.0 or newer
 - Node.js 22.19.0 or newer
 - Interactive TUI mode
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Commands:
 
 The sidebar starts visible and hides when the terminal is too narrow. Press `Ctrl+Shift+R` to resize it.
 
+In Pi fullscreen TUI mode, the sidebar is rendered as a separate split-layout child so transcript selection and copy stay scoped to Pi output. Regular TUI mode remains terminal-native, so a rectangular terminal selection can still include sidebar text.
+
 The TODO panel supports Pi `todo` results and the optional `@juicesharp/rpiv-todo` extension.
 
 Status rail presets:

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
 				"node": ">=22.19.0"
 			},
 			"peerDependencies": {
-				"@earendil-works/pi-coding-agent": ">=0.80.7",
-				"@earendil-works/pi-tui": ">=0.80.7"
+				"@earendil-works/pi-coding-agent": ">=0.84.0",
+				"@earendil-works/pi-tui": ">=0.84.0"
 			}
 		},
 		"node_modules/@biomejs/biome": {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
 		"check": "npm run typecheck && npm run lint && npm run format:check && npm test && npm run check:pack"
 	},
 	"peerDependencies": {
-		"@earendil-works/pi-coding-agent": ">=0.80.7",
-		"@earendil-works/pi-tui": ">=0.80.7"
+		"@earendil-works/pi-coding-agent": ">=0.84.0",
+		"@earendil-works/pi-tui": ">=0.84.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.4",

--- a/src/split-pane.ts
+++ b/src/split-pane.ts
@@ -1,10 +1,9 @@
-import type { Component, OverlayOptions, TUI } from "@earendil-works/pi-tui";
-import { HStack, matchesKey } from "@earendil-works/pi-tui";
+import type { Component, OverlayHandle, OverlayOptions, TUI } from "@earendil-works/pi-tui";
+import { HStack, isViewportTUI, matchesKey } from "@earendil-works/pi-tui";
 
 const ENABLE_MOUSE = "\u001b[?1002h\u001b[?1006h";
 const DISABLE_MOUSE = "\u001b[?1006l\u001b[?1002l";
 const SGR_MOUSE = /^\u001b\[<(\d+);(\d+);(\d+)([Mm])$/;
-const VIEWPORT_TUI = Symbol.for("@earendil-works/pi-tui/viewport");
 const PI_084_REGULAR_RENDER_ADAPTER = Symbol("pi-atelier.regular-render-adapter");
 const PI_084_FULLSCREEN_LAYOUT_ADAPTER = Symbol("pi-atelier.fullscreen-layout-adapter");
 const PI_084_FULLSCREEN_OVERLAY_ADAPTER = Symbol("pi-atelier.fullscreen-overlay-adapter");
@@ -25,15 +24,15 @@ interface FullscreenLayoutAdapterState {
 interface FullscreenOverlayAdapterState {
 	owner: object;
 	baseShowOverlay: TUI["showOverlay"];
+	baseHideOverlay: TUI["hideOverlay"];
 }
 
 type AdaptedTui = TUI & {
-	readonly [VIEWPORT_TUI]?: true;
 	[PI_084_REGULAR_RENDER_ADAPTER]: RegularRenderAdapterState | undefined;
 	[PI_084_FULLSCREEN_LAYOUT_ADAPTER]: FullscreenLayoutAdapterState | undefined;
 	[PI_084_FULLSCREEN_OVERLAY_ADAPTER]: FullscreenOverlayAdapterState | undefined;
 	layoutRoot?: Component;
-	setLayoutRoot?(component: Component | undefined): void;
+	setLayoutRoot(component: Component | undefined): void;
 };
 
 export interface SgrMouseEvent {
@@ -122,6 +121,7 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 	let unsubscribeInput: (() => void) | undefined;
 	let resizeMouseTerminal: TUI["terminal"] | undefined;
 	let fullscreenSidebarComponent: Component | undefined;
+	let fullscreenSidebarHidden = false;
 	let controller: SplitPaneController;
 	const adapterOwner = {};
 
@@ -138,21 +138,25 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 		return undefined;
 	};
 
-	const findPrototypeShowOverlay = (nextTui: TUI): TUI["showOverlay"] | undefined => {
+	const findPrototypeOverlayMethods = (
+		nextTui: TUI,
+	): { showOverlay: TUI["showOverlay"]; hideOverlay: TUI["hideOverlay"] } | undefined => {
 		let prototype = Object.getPrototypeOf(nextTui) as object | null;
-		while (prototype) {
-			const descriptor = Object.getOwnPropertyDescriptor(prototype, "showOverlay");
-			if (typeof descriptor?.value === "function") return descriptor.value as TUI["showOverlay"];
+		let showOverlay: TUI["showOverlay"] | undefined;
+		let hideOverlay: TUI["hideOverlay"] | undefined;
+		while (prototype && (!showOverlay || !hideOverlay)) {
+			const showDescriptor = Object.getOwnPropertyDescriptor(prototype, "showOverlay");
+			if (typeof showDescriptor?.value === "function")
+				showOverlay = showDescriptor.value as TUI["showOverlay"];
+			const hideDescriptor = Object.getOwnPropertyDescriptor(prototype, "hideOverlay");
+			if (typeof hideDescriptor?.value === "function")
+				hideOverlay = hideDescriptor.value as TUI["hideOverlay"];
 			prototype = Object.getPrototypeOf(prototype) as object | null;
 		}
-		return undefined;
+		return showOverlay && hideOverlay ? { showOverlay, hideOverlay } : undefined;
 	};
 
-	const isPiFullscreenRenderer = (): boolean => {
-		if (!tui || tui.mode !== "fullscreen") return false;
-		const adaptedTui = tui as AdaptedTui;
-		return adaptedTui[VIEWPORT_TUI] === true && typeof adaptedTui.setLayoutRoot === "function";
-	};
+	const isPiFullscreenRenderer = (): boolean => tui?.mode === "fullscreen" && isViewportTUI(tui);
 
 	const syncRegularRenderAdapter = () => {
 		if (!tui || tui.mode !== "regular") return;
@@ -192,7 +196,7 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 				visible: ({ width }) => {
 					reconcileResizeWidth(width);
 					syncOverlayWidth(width);
-					return visibleAt(width);
+					return !fullscreenSidebarHidden && visibleAt(width);
 				},
 			},
 		]);
@@ -211,7 +215,7 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 				return;
 			}
 			const splitRoot = createFullscreenSplitRoot(currentState.originalRoot);
-			adaptedTui.setLayoutRoot?.(splitRoot);
+			adaptedTui.setLayoutRoot(splitRoot);
 			currentState.splitRoot = splitRoot;
 			currentState.sidebarWidth = sidebarWidth;
 			currentState.sidebarComponent = fullscreenSidebarComponent;
@@ -219,7 +223,7 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 		}
 		if (!currentRoot) return;
 		const splitRoot = createFullscreenSplitRoot(currentRoot);
-		adaptedTui.setLayoutRoot?.(splitRoot);
+		adaptedTui.setLayoutRoot(splitRoot);
 		adaptedTui[PI_084_FULLSCREEN_LAYOUT_ADAPTER] = {
 			owner: adapterOwner,
 			originalRoot: currentRoot,
@@ -235,7 +239,7 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 		const currentState = adaptedTui[PI_084_FULLSCREEN_LAYOUT_ADAPTER];
 		if (currentState?.owner !== adapterOwner) return;
 		if (adaptedTui.layoutRoot === currentState.splitRoot) {
-			adaptedTui.setLayoutRoot?.(currentState.originalRoot);
+			adaptedTui.setLayoutRoot(currentState.originalRoot);
 		}
 		adaptedTui[PI_084_FULLSCREEN_LAYOUT_ADAPTER] = undefined;
 	};
@@ -246,23 +250,70 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 		const currentState = adaptedTui[PI_084_FULLSCREEN_OVERLAY_ADAPTER];
 		if (currentState?.owner === adapterOwner) return;
 		if (currentState) return;
-		const baseShowOverlay = findPrototypeShowOverlay(tui);
-		if (!baseShowOverlay) return;
-		adaptedTui[PI_084_FULLSCREEN_OVERLAY_ADAPTER] = { owner: adapterOwner, baseShowOverlay };
+		const baseMethods = findPrototypeOverlayMethods(tui);
+		if (!baseMethods) return;
+		const { showOverlay: baseShowOverlay, hideOverlay: baseHideOverlay } = baseMethods;
+		adaptedTui[PI_084_FULLSCREEN_OVERLAY_ADAPTER] = {
+			owner: adapterOwner,
+			baseShowOverlay,
+			baseHideOverlay,
+		};
 		adaptedTui.showOverlay = (component, overlayOptions) => {
 			const state = adaptedTui[PI_084_FULLSCREEN_OVERLAY_ADAPTER];
 			const base = state?.owner === adapterOwner ? state.baseShowOverlay : baseShowOverlay;
 			if (enabled && overlayOptions === overlayLayout && isPiFullscreenRenderer()) {
 				fullscreenSidebarComponent = component;
+				fullscreenSidebarHidden = false;
 				syncFullscreenLayoutAdapter();
 				// ctx.ui.custom() only exposes persistent UI as an overlay. Keep a
 				// non-visible overlay entry for its lifecycle promise, while the
 				// actual Sidebar is rendered by the fullscreen HStack. Pi therefore
 				// sees no visible overlay and can scope selection to the transcript
 				// ScrollView instead of the composed terminal screen.
-				return Reflect.apply(base, tui, [component, { ...overlayOptions, visible: () => false }]);
+				const handle = Reflect.apply(base, tui, [
+					component,
+					{ ...overlayOptions, visible: () => false },
+				]) as OverlayHandle;
+				return {
+					hide() {
+						try {
+							handle.hide();
+						} finally {
+							if (fullscreenSidebarComponent === component) {
+								enabled = false;
+								fullscreenSidebarComponent = undefined;
+								syncFullscreenLayoutAdapter();
+								tui?.requestRender();
+							}
+						}
+					},
+					setHidden(hidden) {
+						handle.setHidden(hidden);
+						if (fullscreenSidebarComponent === component) {
+							fullscreenSidebarHidden = hidden;
+							tui?.requestRender();
+						}
+					},
+					isHidden: () => handle.isHidden(),
+					focus: () => handle.focus(),
+					unfocus: (options) => handle.unfocus(options),
+					isFocused: () => handle.isFocused(),
+				};
 			}
 			return Reflect.apply(base, tui, [component, overlayOptions]);
+		};
+		adaptedTui.hideOverlay = () => {
+			const state = adaptedTui[PI_084_FULLSCREEN_OVERLAY_ADAPTER];
+			const base = state?.owner === adapterOwner ? state.baseHideOverlay : baseHideOverlay;
+			const hadVisibleOverlay = tui?.hasOverlay() ?? false;
+			Reflect.apply(base, tui, []);
+			if (!hadVisibleOverlay && fullscreenSidebarComponent) {
+				enabled = false;
+				fullscreenSidebarComponent = undefined;
+				fullscreenSidebarHidden = false;
+				syncFullscreenLayoutAdapter();
+				tui?.requestRender();
+			}
 		};
 	};
 
@@ -272,6 +323,7 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 		const currentState = adaptedTui[PI_084_FULLSCREEN_OVERLAY_ADAPTER];
 		if (currentState?.owner !== adapterOwner) return;
 		adaptedTui.showOverlay = currentState.baseShowOverlay;
+		adaptedTui.hideOverlay = currentState.baseHideOverlay;
 		adaptedTui[PI_084_FULLSCREEN_OVERLAY_ADAPTER] = undefined;
 	};
 
@@ -439,6 +491,7 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 			if (!enabled) return;
 			enabled = false;
 			fullscreenSidebarComponent = undefined;
+			fullscreenSidebarHidden = false;
 			syncFullscreenLayoutAdapter();
 			requestRender();
 		},
@@ -498,6 +551,7 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 			disposed = true;
 			enabled = false;
 			fullscreenSidebarComponent = undefined;
+			fullscreenSidebarHidden = false;
 			restoreRegularRenderAdapter();
 			restoreFullscreenOverlayAdapter();
 			restoreFullscreenLayoutAdapter();

--- a/src/split-pane.ts
+++ b/src/split-pane.ts
@@ -4,8 +4,10 @@ import { HStack, matchesKey } from "@earendil-works/pi-tui";
 const ENABLE_MOUSE = "\u001b[?1002h\u001b[?1006h";
 const DISABLE_MOUSE = "\u001b[?1006l\u001b[?1002l";
 const SGR_MOUSE = /^\u001b\[<(\d+);(\d+);(\d+)([Mm])$/;
+const VIEWPORT_TUI = Symbol.for("@earendil-works/pi-tui/viewport");
 const PI_084_REGULAR_RENDER_ADAPTER = Symbol("pi-atelier.regular-render-adapter");
 const PI_084_FULLSCREEN_LAYOUT_ADAPTER = Symbol("pi-atelier.fullscreen-layout-adapter");
+const PI_084_FULLSCREEN_OVERLAY_ADAPTER = Symbol("pi-atelier.fullscreen-overlay-adapter");
 
 interface RegularRenderAdapterState {
 	owner: object;
@@ -17,13 +19,21 @@ interface FullscreenLayoutAdapterState {
 	originalRoot: Component;
 	splitRoot: Component;
 	sidebarWidth: number;
+	sidebarComponent: Component | undefined;
+}
+
+interface FullscreenOverlayAdapterState {
+	owner: object;
+	baseShowOverlay: TUI["showOverlay"];
 }
 
 type AdaptedTui = TUI & {
+	readonly [VIEWPORT_TUI]?: true;
 	[PI_084_REGULAR_RENDER_ADAPTER]: RegularRenderAdapterState | undefined;
 	[PI_084_FULLSCREEN_LAYOUT_ADAPTER]: FullscreenLayoutAdapterState | undefined;
+	[PI_084_FULLSCREEN_OVERLAY_ADAPTER]: FullscreenOverlayAdapterState | undefined;
 	layoutRoot?: Component;
-	setLayoutRoot(component: Component | undefined): void;
+	setLayoutRoot?(component: Component | undefined): void;
 };
 
 export interface SgrMouseEvent {
@@ -83,6 +93,11 @@ const finiteInteger = (value: number, fallback: number): number =>
 const clamp = (value: number, minimum: number, maximum: number): number =>
 	Math.min(maximum, Math.max(minimum, value));
 
+const EMPTY_SIDEBAR_COMPONENT: Component = {
+	render: () => [],
+	invalidate() {},
+};
+
 export function createSplitPaneController(options: SplitPaneControllerOptions = {}): SplitPaneController {
 	const minimumSidebar = Math.max(
 		1,
@@ -106,6 +121,7 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 	let dragging = false;
 	let unsubscribeInput: (() => void) | undefined;
 	let resizeMouseTerminal: TUI["terminal"] | undefined;
+	let fullscreenSidebarComponent: Component | undefined;
 	let controller: SplitPaneController;
 	const adapterOwner = {};
 
@@ -120,6 +136,22 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 			prototype = Object.getPrototypeOf(prototype) as object | null;
 		}
 		return undefined;
+	};
+
+	const findPrototypeShowOverlay = (nextTui: TUI): TUI["showOverlay"] | undefined => {
+		let prototype = Object.getPrototypeOf(nextTui) as object | null;
+		while (prototype) {
+			const descriptor = Object.getOwnPropertyDescriptor(prototype, "showOverlay");
+			if (typeof descriptor?.value === "function") return descriptor.value as TUI["showOverlay"];
+			prototype = Object.getPrototypeOf(prototype) as object | null;
+		}
+		return undefined;
+	};
+
+	const isPiFullscreenRenderer = (): boolean => {
+		if (!tui || tui.mode !== "fullscreen") return false;
+		const adaptedTui = tui as AdaptedTui;
+		return adaptedTui[VIEWPORT_TUI] === true && typeof adaptedTui.setLayoutRoot === "function";
 	};
 
 	const syncRegularRenderAdapter = () => {
@@ -151,40 +183,49 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 		new HStack([
 			{ component: originalRoot, basis: 0, grow: 1, shrink: 1, minSize: minimumMain },
 			{
-				component: { render: () => [], invalidate() {} },
+				component: fullscreenSidebarComponent ?? EMPTY_SIDEBAR_COMPONENT,
 				basis: sidebarWidth,
 				grow: 0,
 				shrink: 1,
 				minSize: minimumSidebar,
 				maxSize: maximumSidebar,
-				visible: ({ width }) => visibleAt(width),
+				visible: ({ width }) => {
+					reconcileResizeWidth(width);
+					syncOverlayWidth(width);
+					return visibleAt(width);
+				},
 			},
 		]);
 
 	const syncFullscreenLayoutAdapter = () => {
-		if (!tui || tui.mode !== "fullscreen") return;
+		if (!isPiFullscreenRenderer() || !tui) return;
 		const adaptedTui = tui as AdaptedTui;
-		const prototype = Object.getPrototypeOf(tui) as { constructor?: { name?: string } } | null;
-		if (prototype?.constructor?.name !== "TuiAltScreen") return;
 		const currentState = adaptedTui[PI_084_FULLSCREEN_LAYOUT_ADAPTER];
 		if (currentState && currentState.owner !== adapterOwner) return;
 		const currentRoot = adaptedTui.layoutRoot;
 		if (currentState?.owner === adapterOwner && currentRoot === currentState.splitRoot) {
-			if (currentState.sidebarWidth === sidebarWidth) return;
+			if (
+				currentState.sidebarWidth === sidebarWidth &&
+				currentState.sidebarComponent === fullscreenSidebarComponent
+			) {
+				return;
+			}
 			const splitRoot = createFullscreenSplitRoot(currentState.originalRoot);
-			adaptedTui.setLayoutRoot(splitRoot);
+			adaptedTui.setLayoutRoot?.(splitRoot);
 			currentState.splitRoot = splitRoot;
 			currentState.sidebarWidth = sidebarWidth;
+			currentState.sidebarComponent = fullscreenSidebarComponent;
 			return;
 		}
 		if (!currentRoot) return;
 		const splitRoot = createFullscreenSplitRoot(currentRoot);
-		adaptedTui.setLayoutRoot(splitRoot);
+		adaptedTui.setLayoutRoot?.(splitRoot);
 		adaptedTui[PI_084_FULLSCREEN_LAYOUT_ADAPTER] = {
 			owner: adapterOwner,
 			originalRoot: currentRoot,
 			splitRoot,
 			sidebarWidth,
+			sidebarComponent: fullscreenSidebarComponent,
 		};
 	};
 
@@ -194,15 +235,44 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 		const currentState = adaptedTui[PI_084_FULLSCREEN_LAYOUT_ADAPTER];
 		if (currentState?.owner !== adapterOwner) return;
 		if (adaptedTui.layoutRoot === currentState.splitRoot) {
-			adaptedTui.setLayoutRoot(currentState.originalRoot);
+			adaptedTui.setLayoutRoot?.(currentState.originalRoot);
 		}
 		adaptedTui[PI_084_FULLSCREEN_LAYOUT_ADAPTER] = undefined;
 	};
 
-	const isPiFullscreenRenderer = (): boolean => {
-		if (!tui || tui.mode !== "fullscreen") return false;
-		const prototype = Object.getPrototypeOf(tui) as { constructor?: { name?: string } } | null;
-		return prototype?.constructor?.name === "TuiAltScreen";
+	const syncFullscreenOverlayAdapter = () => {
+		if (!isPiFullscreenRenderer() || !tui) return;
+		const adaptedTui = tui as AdaptedTui;
+		const currentState = adaptedTui[PI_084_FULLSCREEN_OVERLAY_ADAPTER];
+		if (currentState?.owner === adapterOwner) return;
+		if (currentState) return;
+		const baseShowOverlay = findPrototypeShowOverlay(tui);
+		if (!baseShowOverlay) return;
+		adaptedTui[PI_084_FULLSCREEN_OVERLAY_ADAPTER] = { owner: adapterOwner, baseShowOverlay };
+		adaptedTui.showOverlay = (component, overlayOptions) => {
+			const state = adaptedTui[PI_084_FULLSCREEN_OVERLAY_ADAPTER];
+			const base = state?.owner === adapterOwner ? state.baseShowOverlay : baseShowOverlay;
+			if (enabled && overlayOptions === overlayLayout && isPiFullscreenRenderer()) {
+				fullscreenSidebarComponent = component;
+				syncFullscreenLayoutAdapter();
+				// ctx.ui.custom() only exposes persistent UI as an overlay. Keep a
+				// non-visible overlay entry for its lifecycle promise, while the
+				// actual Sidebar is rendered by the fullscreen HStack. Pi therefore
+				// sees no visible overlay and can scope selection to the transcript
+				// ScrollView instead of the composed terminal screen.
+				return Reflect.apply(base, tui, [component, { ...overlayOptions, visible: () => false }]);
+			}
+			return Reflect.apply(base, tui, [component, overlayOptions]);
+		};
+	};
+
+	const restoreFullscreenOverlayAdapter = () => {
+		if (!tui) return;
+		const adaptedTui = tui as AdaptedTui;
+		const currentState = adaptedTui[PI_084_FULLSCREEN_OVERLAY_ADAPTER];
+		if (currentState?.owner !== adapterOwner) return;
+		adaptedTui.showOverlay = currentState.baseShowOverlay;
+		adaptedTui[PI_084_FULLSCREEN_OVERLAY_ADAPTER] = undefined;
 	};
 
 	const prioritizeFullscreenResizeInput = (
@@ -257,7 +327,12 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 		overlayLayout.width = effectiveWidth > 0 ? effectiveWidth : sidebarWidth;
 	};
 
-	const requestRender = () => tui?.requestRender();
+	const requestRender = () => {
+		syncRegularRenderAdapter();
+		syncFullscreenLayoutAdapter();
+		syncFullscreenOverlayAdapter();
+		tui?.requestRender();
+	};
 
 	const stopResize = (restore: boolean) => {
 		if (!resizing && !resizeMouseTerminal && !unsubscribeInput) return;
@@ -295,6 +370,7 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 		syncOverlayWidth(nextTui.terminal.columns);
 		syncRegularRenderAdapter();
 		syncFullscreenLayoutAdapter();
+		syncFullscreenOverlayAdapter();
 		requestRender();
 	};
 
@@ -355,12 +431,15 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 			syncOverlayWidth();
 			syncRegularRenderAdapter();
 			syncFullscreenLayoutAdapter();
+			syncFullscreenOverlayAdapter();
 			requestRender();
 		},
 		hide() {
 			stopResize(true);
 			if (!enabled) return;
 			enabled = false;
+			fullscreenSidebarComponent = undefined;
+			syncFullscreenLayoutAdapter();
 			requestRender();
 		},
 		setSidebarWidth(width) {
@@ -418,7 +497,9 @@ export function createSplitPaneController(options: SplitPaneControllerOptions = 
 			stopResize(true);
 			disposed = true;
 			enabled = false;
+			fullscreenSidebarComponent = undefined;
 			restoreRegularRenderAdapter();
+			restoreFullscreenOverlayAdapter();
 			restoreFullscreenLayoutAdapter();
 			tui?.requestRender();
 			tui = undefined;

--- a/tests/fullscreen-copy-safe-sidebar.test.ts
+++ b/tests/fullscreen-copy-safe-sidebar.test.ts
@@ -1,7 +1,9 @@
 import type { TUI } from "@earendil-works/pi-tui";
 import { ScrollView, TuiAltScreen } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
+import { createSidebarController } from "../src/sidebar.js";
 import { createSplitPaneController } from "../src/split-pane.js";
+import { DEFAULT_CONFIG } from "../src/types.js";
 
 const press = (x: number, y: number) => `\u001b[<0;${x};${y}M`;
 const motion = (x: number, y: number) => `\u001b[<32;${x};${y}M`;
@@ -29,6 +31,74 @@ function stableTuiReference(getRenderer: () => TUI): TUI {
 }
 
 describe("fullscreen Sidebar selection", () => {
+	it("removes the split child immediately when ctx.ui.custom closes its lifecycle overlay", async () => {
+		const terminal = {
+			columns: 120,
+			rows: 8,
+			write: vi.fn(),
+			start: vi.fn(),
+			stop: vi.fn(),
+			hideCursor: vi.fn(),
+			showCursor: vi.fn(),
+		};
+		const renderer = new TuiAltScreen(terminal as never);
+		const tui = stableTuiReference(() => renderer);
+		const mainWidths: number[] = [];
+		renderer.setLayoutRoot({
+			render: (width) => {
+				mainWidths.push(width);
+				return [`main:${width}`];
+			},
+			invalidate() {},
+		});
+		let closeCustom: (() => void) | undefined;
+		const custom = vi.fn(
+			(factory, options) =>
+				new Promise<void>((resolve) => {
+					const done = () => {
+						tui.hideOverlay();
+						resolve();
+					};
+					closeCustom = done;
+					const component = factory(
+						tui,
+						{
+							name: "dark",
+							fg: (_color: string, text: string) => text,
+							bold: (text: string) => text,
+							italic: (text: string) => text,
+						},
+						{},
+						done,
+					);
+					const overlayOptions =
+						typeof options.overlayOptions === "function" ? options.overlayOptions() : options.overlayOptions;
+					const handle = tui.showOverlay(component, overlayOptions);
+					options.onHandle?.(handle);
+				}),
+		);
+		const controller = createSidebarController({
+			ctx: { mode: "tui", ui: { custom } } as never,
+			getSnapshot: () => {
+				throw new Error("render lifecycle marker");
+			},
+			getConfig: () => DEFAULT_CONFIG,
+		});
+
+		controller.show();
+		tui.render(120);
+		expect(mainWidths.at(-1)).toBe(76);
+
+		closeCustom?.();
+		tui.render(120);
+		expect(mainWidths.at(-1)).toBe(120);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(controller.isVisible()).toBe(false);
+
+		controller.dispose();
+	});
+
 	it("copies transcript content without Sidebar text through Pi's stable TUI reference", () => {
 		let deliverInput: ((data: string) => void) | undefined;
 		const write = vi.fn();
@@ -87,7 +157,18 @@ describe("fullscreen Sidebar selection", () => {
 		expect(copied).not.toContain("SIDEBAR");
 		expect(copied).not.toContain("TOKEN BURDEN");
 
+		overlayHandle.setHidden(true);
+		expect(overlayHandle.isHidden()).toBe(true);
+		expect(tui.render(120).join("\n")).not.toContain("SIDEBAR");
+		overlayHandle.setHidden(false);
+		expect(tui.render(120).join("\n")).toContain("SIDEBAR");
+
+		tui.hideOverlay();
+		expect(tui.render(120).join("\n")).not.toContain("SIDEBAR");
+
 		overlayHandle.hide();
+		expect(tui.render(120).join("\n")).not.toContain("SIDEBAR");
+		expect(tui.render(120).join("\n")).not.toContain("TOKEN BURDEN");
 		split.dispose();
 		renderer.stop();
 	});

--- a/tests/fullscreen-copy-safe-sidebar.test.ts
+++ b/tests/fullscreen-copy-safe-sidebar.test.ts
@@ -1,0 +1,71 @@
+import { ScrollView, TuiAltScreen } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { createSplitPaneController } from "../src/split-pane.js";
+
+const press = (x: number, y: number) => `\u001b[<0;${x};${y}M`;
+const motion = (x: number, y: number) => `\u001b[<32;${x};${y}M`;
+const release = (x: number, y: number) => `\u001b[<0;${x};${y}m`;
+
+describe("fullscreen Sidebar selection", () => {
+	it("copies transcript content without Sidebar text", () => {
+		let deliverInput: ((data: string) => void) | undefined;
+		const write = vi.fn();
+		const terminal = {
+			columns: 120,
+			rows: 8,
+			write,
+			start: vi.fn((onInput: (data: string) => void) => {
+				deliverInput = onInput;
+			}),
+			stop: vi.fn(),
+			hideCursor: vi.fn(),
+			showCursor: vi.fn(),
+		};
+		const renderer = new TuiAltScreen(terminal as never);
+		const transcript = new ScrollView(
+			{
+				render: () => ["alpha", "beta", "gamma"],
+				invalidate() {},
+			},
+			{ primary: true },
+		);
+		renderer.setLayoutRoot(transcript);
+		renderer.start();
+
+		const split = createSplitPaneController();
+		split.attach(renderer);
+		split.show();
+		const overlayHandle = renderer.showOverlay(
+			{
+				render: () => ["SIDEBAR", "TOKEN BURDEN"],
+				invalidate() {},
+			},
+			split.overlayOptions(),
+		);
+		renderer.renderNow();
+
+		// The Sidebar is visibly part of the HStack, but its lifecycle overlay is
+		// non-visible so Pi can bind text selection to the transcript ScrollView.
+		expect(renderer.render(120).join("\n")).toContain("SIDEBAR");
+		expect(renderer.hasOverlay()).toBe(false);
+
+		deliverInput?.(press(1, 1));
+		deliverInput?.(motion(4, 2));
+		deliverInput?.(release(4, 2));
+
+		const copyWrite = write.mock.calls
+			.map(([value]) => String(value))
+			.findLast((value) => value.includes("\u001b]52;c;"));
+		expect(copyWrite).toBeDefined();
+		const encoded = copyWrite?.match(/\u001b\]52;c;([A-Za-z0-9+/=]+)\u0007/)?.[1];
+		expect(encoded).toBeDefined();
+		const copied = Buffer.from(encoded ?? "", "base64").toString("utf8");
+		expect(copied).toBe("alpha\nbeta");
+		expect(copied).not.toContain("SIDEBAR");
+		expect(copied).not.toContain("TOKEN BURDEN");
+
+		overlayHandle.hide();
+		split.dispose();
+		renderer.stop();
+	});
+});

--- a/tests/fullscreen-copy-safe-sidebar.test.ts
+++ b/tests/fullscreen-copy-safe-sidebar.test.ts
@@ -1,3 +1,4 @@
+import type { TUI } from "@earendil-works/pi-tui";
 import { ScrollView, TuiAltScreen } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
 import { createSplitPaneController } from "../src/split-pane.js";
@@ -6,8 +7,29 @@ const press = (x: number, y: number) => `\u001b[<0;${x};${y}M`;
 const motion = (x: number, y: number) => `\u001b[<32;${x};${y}M`;
 const release = (x: number, y: number) => `\u001b[<0;${x};${y}m`;
 
+function stableTuiReference(getRenderer: () => TUI): TUI {
+	return new Proxy({} as TUI, {
+		get: (_target, property) => {
+			const renderer = getRenderer();
+			const value = Reflect.get(renderer, property, renderer);
+			if (typeof value !== "function") return value;
+			return (...args: unknown[]) => {
+				const currentRenderer = getRenderer();
+				const method = Reflect.get(currentRenderer, property, currentRenderer);
+				if (typeof method !== "function") throw new TypeError(`${String(property)} is not callable`);
+				return Reflect.apply(method, currentRenderer, args);
+			};
+		},
+		set: (_target, property, value) => {
+			const renderer = getRenderer();
+			return Reflect.set(renderer, property, value, renderer);
+		},
+		getPrototypeOf: () => Reflect.getPrototypeOf(getRenderer()),
+	}) as TUI;
+}
+
 describe("fullscreen Sidebar selection", () => {
-	it("copies transcript content without Sidebar text", () => {
+	it("copies transcript content without Sidebar text through Pi's stable TUI reference", () => {
 		let deliverInput: ((data: string) => void) | undefined;
 		const write = vi.fn();
 		const terminal = {
@@ -22,6 +44,7 @@ describe("fullscreen Sidebar selection", () => {
 			showCursor: vi.fn(),
 		};
 		const renderer = new TuiAltScreen(terminal as never);
+		const tui = stableTuiReference(() => renderer);
 		const transcript = new ScrollView(
 			{
 				render: () => ["alpha", "beta", "gamma"],
@@ -33,9 +56,9 @@ describe("fullscreen Sidebar selection", () => {
 		renderer.start();
 
 		const split = createSplitPaneController();
-		split.attach(renderer);
+		split.attach(tui);
 		split.show();
-		const overlayHandle = renderer.showOverlay(
+		const overlayHandle = tui.showOverlay(
 			{
 				render: () => ["SIDEBAR", "TOKEN BURDEN"],
 				invalidate() {},
@@ -46,8 +69,8 @@ describe("fullscreen Sidebar selection", () => {
 
 		// The Sidebar is visibly part of the HStack, but its lifecycle overlay is
 		// non-visible so Pi can bind text selection to the transcript ScrollView.
-		expect(renderer.render(120).join("\n")).toContain("SIDEBAR");
-		expect(renderer.hasOverlay()).toBe(false);
+		expect(tui.render(120).join("\n")).toContain("SIDEBAR");
+		expect(tui.hasOverlay()).toBe(false);
 
 		deliverInput?.(press(1, 1));
 		deliverInput?.(motion(4, 2));

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -29,8 +29,8 @@ describe("npm package contract", () => {
 		expect(pkg.description).toBe("A responsive status rail and live activity sidebar for Pi");
 		expect(pkg.keywords).toContain("pi-package");
 		expect(pkg.pi.extensions).toEqual(["./extensions/index.ts"]);
-		expect(pkg.peerDependencies["@earendil-works/pi-coding-agent"]).toBe(">=0.80.7");
-		expect(pkg.peerDependencies["@earendil-works/pi-tui"]).toBe(">=0.80.7");
+		expect(pkg.peerDependencies["@earendil-works/pi-coding-agent"]).toBe(">=0.84.0");
+		expect(pkg.peerDependencies["@earendil-works/pi-tui"]).toBe(">=0.84.0");
 		expect(pkg.engines.node).toBe(">=22.19.0");
 		expect(pkg.files).toEqual(expect.arrayContaining(["extensions", "src", "README.md", "LICENSE"]));
 	});


### PR DESCRIPTION
## Summary

Fix fullscreen transcript copy contamination by rendering the visible Pi Atelier Sidebar as the second child of the existing fullscreen `HStack` instead of as a visible Pi overlay.

Pi's extension API still supplies the Sidebar component through `ctx.ui.custom(..., { overlay: true })`, so fullscreen keeps only a non-visible lifecycle overlay entry. The Sidebar itself is rendered by the split layout.

This keeps Pi's fullscreen selection scoped to the transcript `ScrollView`, so multiline copy no longer includes Sidebar content.

The implementation uses Pi 0.84's public `isViewportTUI()` guard, preserves `OverlayHandle` hide/visibility semantics, and removes the split child immediately when the `ctx.ui.custom()` lifecycle overlay closes. Pi Atelier now requires Pi 0.84.0 or newer.

## Issue and scope

- [x] I linked the issue for this change, when an issue was required.
- [x] This PR contains one coherent change or user-facing behavior.
- [x] Unrelated changes and non-goals are called out below or split into another PR.

Closes #34

**Scope / non-goals:** Fullscreen TUI selection/copy only. Regular mode intentionally retains terminal-native selection behavior and may still include Sidebar cells in rectangular terminal selections.

## Validation

- [x] I ran `npm run check` (mandatory for every PR, including docs-only; it is the complete repository gate).
- [x] I ran `git diff --check upstream/main...HEAD` against the updated `main`.
- [x] I added or updated regression tests through the relevant public/runtime seam for behavior changes.
- [x] For configuration, event, or sidebar behavior, relevant edge cases are covered or explained below.
- [x] For TUI changes (sidebar, footer, menu, or overlay), I manually validated with an equivalent supported global `pi -e .`.
- [ ] For TUI changes, I provided a screenshot/recording URL or attached artifact, terminal dimensions/context, and observed result below.

**Commands and results:**

`npm run check` passes under WSL/Linux.

`git diff --check upstream/main...HEAD` passes with no output.

The fullscreen copy and `ctx.ui.custom()` lifecycle regressions pass. The complete suite passes: 16 test files and 455 tests.

The full suite has also been exercised on native Windows. Existing unrelated path-normalization tests assume POSIX separators and fail there; the complete repository gate passes under Linux.

**Manual validation:**

Validated on native Windows with:

`pi -ne -e . --tui-mode fullscreen`

With only the local Atelier checkout loaded, one Sidebar rendered. Multiline transcript selection copied transcript text without any Sidebar content.

Maintainer QA also passed in fullscreen mode with Pi 0.84.0: multiline transcript copy excluded all Sidebar content. Regular mode remains an intentional non-goal because selection is terminal-native. The maintainer explicitly waived the screenshot/recording and terminal-dimension artifact for this PR.

## Documentation and compatibility

- [x] I updated `README.md` and `CHANGELOG.md` under `Unreleased` when this user-visible change requires it.
- [x] Configuration or documentation impact is described below.
- [x] Known limitations and compatibility considerations are described below.

**Config/docs impact:** No configuration changes. README and contributing guidance now require Pi 0.84.0 and document fullscreen copy isolation plus the regular-mode limitation.

**Known limitations:** Pi does not currently expose an extension API for mounting a persistent arbitrary layout child. Atelier therefore still uses the `ctx.ui.custom()` overlay lifecycle seam, but the fullscreen lifecycle entry is permanently non-visible; the visible Sidebar is the `HStack` child. Pi 0.84.0 or newer is required. Regular mode is unchanged.

## Release safety

- [x] This PR does not publish packages, change release versions, create tags/releases, or edit npm publishing credentials.