### PR TITLE
Fix Windows path separator consistency

### DIFF
--- a/src/display-path.ts
+++ b/src/display-path.ts
@@ -1,0 +1,4 @@
+/** Formats a filesystem path for stable, cross-platform UI display. */
+export function toDisplayPath(value: string, separator: "/" | "\\"): string {
+	return separator === "/" ? value : value.replaceAll(separator, "/");
+}

--- a/src/run-activity.ts
+++ b/src/run-activity.ts
@@ -1,5 +1,6 @@
 import nodePath from "node:path";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { toDisplayPath } from "./display-path.js";
 import type { DisplayValue, ResponsePerformance } from "./types.js";
 
 export type ToolActivityStatus = "running" | "done" | "failed";
@@ -429,16 +430,18 @@ function shortenPath(pathValue: string, cwd: string): string {
 		: nodePath.resolve(normalizedCwd, safePath);
 
 	const projectRelativePath = safeRelativePath(normalizedCwd, normalizedPath);
-	if (projectRelativePath !== undefined) return projectRelativePath;
+	if (projectRelativePath !== undefined) return toDisplayPath(projectRelativePath, nodePath.sep);
 
 	const home = sanitizeText(process.env.HOME ?? "");
 	if (home.length > 0) {
 		const normalizedHome = nodePath.resolve(home);
 		const homeRelativePath = safeRelativePath(normalizedHome, normalizedPath);
-		if (homeRelativePath !== undefined) return homeRelativePath === "." ? "~" : `~/${homeRelativePath}`;
+		if (homeRelativePath !== undefined) {
+			return homeRelativePath === "." ? "~" : `~/${toDisplayPath(homeRelativePath, nodePath.sep)}`;
+		}
 	}
 
-	return normalizedPath;
+	return toDisplayPath(normalizedPath, nodePath.sep);
 }
 
 function safeRelativePath(fromPath: string, toPath: string): string | undefined {

--- a/src/workspace-pulse.ts
+++ b/src/workspace-pulse.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import nodePath from "node:path";
+import { toDisplayPath } from "./display-path.js";
 
 export interface WorkspacePulseSnapshot {
 	trackedFiles: number;
@@ -295,7 +296,7 @@ async function inspectWorkspacePulseUnchecked(
 	return {
 		kind: "available",
 		root,
-		relativeCwd: nodePath.relative(root, options.cwd),
+		relativeCwd: toDisplayPath(nodePath.relative(root, options.cwd), nodePath.sep),
 		...(parsedStatus.branch ? { branch: parsedStatus.branch } : {}),
 		snapshot: {
 			...EMPTY_SNAPSHOT,

--- a/tests/display-path.test.ts
+++ b/tests/display-path.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { toDisplayPath } from "../src/display-path.js";
+
+describe("toDisplayPath", () => {
+	it("uses forward slashes for Windows UI-facing paths", () => {
+		expect(toDisplayPath("packages\\api\\src", "\\")).toBe("packages/api/src");
+		expect(toDisplayPath("C:\\repo\\src\\state.ts", "\\")).toBe("C:/repo/src/state.ts");
+	});
+
+	it("preserves backslashes that are valid POSIX filename characters", () => {
+		expect(toDisplayPath("src/file\\name.ts", "/")).toBe("src/file\\name.ts");
+	});
+});


### PR DESCRIPTION
## Summary

- normalize UI-facing paths to forward slashes across platforms
- apply the display-path contract to run activity summaries and Workspace Pulse
- preserve valid POSIX backslashes by converting only the native path separator
- add regression coverage for Windows-style relative and absolute paths

## Validation

- `npm run check`
- 17 test files passed, 457 tests passed

Closes #36
