### PR TITLE
Polish composer frame and Status Rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Frame the composer with a rounded box and inner padding while keeping Pi's thinking-level and bash-mode border colors.
+- Dim Status Rail identity separators so model, thinking, and git recede against the activity jewel.
 - Render the fullscreen Sidebar inside Pi's split layout instead of as a visible overlay so transcript selection and copy exclude Sidebar content; this now requires Pi 0.84.0 or newer.
 - Wait to run Workspace Pulse Git inspections until Pi considers the project trusted.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Status rail presets:
 - **minimal**: compact layout
 - **classic**: detailed telemetry
 
-Pi supports one custom footer at a time. Extension load order determines which footer is visible.
+The composer uses a rounded frame with inner padding. Thinking-level and bash-mode still color that frame through Pi.
+
+Pi supports one custom footer and one custom editor at a time. Extension load order determines which chrome is visible.
 
 ## Configuration
 

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -15,6 +15,7 @@ import {
 	type SpawnNotificationProcess,
 } from "../src/completion-notifier.js";
 import { loadConfig, type saveUserConfig, saveUserConfigPatch } from "../src/config.js";
+import { AtelierEditor } from "../src/editor.js";
 import { createFooterComponent, type ThemeLike } from "../src/footer.js";
 import {
 	type DisplaySettingsRuntime,
@@ -319,6 +320,11 @@ export default function atelierExtension(
 			} catch {
 				// Pi may retain the old footer when removal fails; dispose it below regardless.
 			}
+			try {
+				session.ctx.ui.setEditorComponent(undefined);
+			} catch {
+				// Composer restoration is best-effort and must not mask footer teardown.
+			}
 		}
 		try {
 			footerDisposer?.();
@@ -367,6 +373,11 @@ export default function atelierExtension(
 				ctx?.ui.setFooter(undefined);
 			} catch {
 				// No-active cleanup must not mask the original lifecycle failure.
+			}
+			try {
+				ctx?.ui.setEditorComponent(undefined);
+			} catch {
+				// Composer restoration is best-effort during no-active cleanup.
 			}
 		}
 	}
@@ -557,6 +568,11 @@ export default function atelierExtension(
 			else component.dispose();
 			return component;
 		});
+		try {
+			ctx.ui.setEditorComponent((tui, theme, keybindings) => new AtelierEditor(tui, theme, keybindings));
+		} catch {
+			// Composer framing is optional; the Status Rail should still install.
+		}
 	}
 
 	pi.registerCommand("atelier", {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,0 +1,88 @@
+import { CustomEditor } from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+
+/** │ + padding on each side. */
+export const EDITOR_FRAME_CHROME = 4;
+export const EDITOR_FRAME_MIN_WIDTH = 6;
+
+const RULE_PATTERN = /^─+(?: [↑↓] \d+ more ─*)?(?:\.{0,3})?$/;
+
+export function isEditorRuleText(plain: string): boolean {
+	return plain.length > 0 && RULE_PATTERN.test(plain);
+}
+
+function padToVisible(text: string, width: number): string {
+	const current = visibleWidth(text);
+	if (current === width) return text;
+	if (current > width) return truncateToWidth(text, width, "");
+	return `${text}${" ".repeat(width - current)}`;
+}
+
+function expandRule(line: string, width: number): string {
+	const plain = stripTerminalSequences(line);
+	const body = isEditorRuleText(plain) ? plain : "─".repeat(Math.max(0, visibleWidth(plain)));
+	if (visibleWidth(body) >= width) return padToVisible(body, width);
+	return `${body}${"─".repeat(width - visibleWidth(body))}`;
+}
+
+function findBottomRuleIndex(lines: readonly string[], innerWidth: number): number {
+	for (let index = lines.length - 1; index >= 1; index -= 1) {
+		const line = lines[index];
+		if (!line) continue;
+		const plain = stripTerminalSequences(line);
+		if (visibleWidth(plain) === innerWidth && isEditorRuleText(plain)) return index;
+	}
+	return Math.max(0, lines.length - 1);
+}
+
+function framedRule(
+	innerRule: string,
+	outerBodyWidth: number,
+	leftCap: string,
+	rightCap: string,
+	borderColor: (text: string) => string,
+): string {
+	return borderColor(`${leftCap}${expandRule(innerRule, outerBodyWidth)}${rightCap}`);
+}
+
+function framedRow(line: string, innerWidth: number, borderColor: (text: string) => string): string {
+	return `${borderColor("│")} ${padToVisible(line, innerWidth)} ${borderColor("│")}`;
+}
+
+/** Wrap Pi editor lines in a rounded frame with one column of inner padding. */
+export function frameEditorLines(
+	inner: readonly string[],
+	width: number,
+	borderColor: (text: string) => string,
+): string[] {
+	const safeWidth = Math.max(0, Math.trunc(width));
+	if (safeWidth < EDITOR_FRAME_MIN_WIDTH || inner.length === 0) {
+		return inner.map((line) => truncateToWidth(line, safeWidth, ""));
+	}
+
+	const innerWidth = safeWidth - EDITOR_FRAME_CHROME;
+	const outerBodyWidth = safeWidth - 2;
+	const bottom = findBottomRuleIndex(inner, innerWidth);
+	const topRule = inner[0] ?? "─".repeat(innerWidth);
+	const bottomRule = inner[bottom] ?? "─".repeat(innerWidth);
+	const framed: string[] = [framedRule(topRule, outerBodyWidth, "╭", "╮", borderColor)];
+
+	for (let index = 1; index < bottom; index += 1) {
+		framed.push(framedRow(inner[index] ?? "", innerWidth, borderColor));
+	}
+	for (let index = bottom + 1; index < inner.length; index += 1) {
+		framed.push(framedRow(inner[index] ?? "", innerWidth, borderColor));
+	}
+
+	framed.push(framedRule(bottomRule, outerBodyWidth, "╰", "╯", borderColor));
+	return framed.map((line) => truncateToWidth(line, safeWidth, ""));
+}
+
+/** Pi composer with Atelier's rounded frame. Preserves thinking-level borderColor. */
+export class AtelierEditor extends CustomEditor {
+	override render(width: number): string[] {
+		const safeWidth = Math.max(0, Math.trunc(width));
+		if (safeWidth < EDITOR_FRAME_MIN_WIDTH) return super.render(safeWidth);
+		return frameEditorLines(super.render(safeWidth - EDITOR_FRAME_CHROME), safeWidth, this.borderColor);
+	}
+}

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -347,14 +347,14 @@ function renderItems(items: FooterItem[], compactIds: Set<FooterItemId>, separat
 		.join(separator);
 }
 
-function compose(items: FooterItem[], width: number): string {
+function compose(items: FooterItem[], width: number, leftSeparator: string): string {
 	const active = [...items];
 	const compactIds = new Set<FooterItemId>();
 	const left = () =>
 		renderItems(
 			active.filter((item) => item.zone === "left"),
 			compactIds,
-			" · ",
+			leftSeparator,
 		);
 	const right = () =>
 		renderItems(
@@ -392,7 +392,12 @@ export function renderFooterLine(
 	workingDots = "...",
 ): string {
 	if (width <= 0) return "";
-	const line = compose(buildItems(state, config, theme, colorEnabled, workingDots), width);
+	const palette = createPalette(theme, colorEnabled);
+	const line = compose(
+		buildItems(state, config, theme, colorEnabled, workingDots),
+		width,
+		palette.paint("dim", " · "),
+	);
 	return truncateToWidth(line, width, "");
 }
 

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -1,0 +1,75 @@
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { AtelierEditor, EDITOR_FRAME_MIN_WIDTH, frameEditorLines, isEditorRuleText } from "../src/editor.js";
+
+const paint = (text: string) => `\u001b[38;2;102;102;102m${text}\u001b[39m`;
+
+describe("editor frame helpers", () => {
+	it("recognizes plain and scroll editor rules", () => {
+		expect(isEditorRuleText("─".repeat(20))).toBe(true);
+		expect(isEditorRuleText(`─── ↑ 3 more ${"─".repeat(8)}`)).toBe(true);
+		expect(isEditorRuleText(`─── ↓ 12 more ${"─".repeat(6)}`)).toBe(true);
+		expect(isEditorRuleText("prompt text")).toBe(false);
+		expect(isEditorRuleText("")).toBe(false);
+	});
+
+	it("frames content with rounded corners, side rails, and inner padding", () => {
+		const innerWidth = 12;
+		const inner = ["─".repeat(innerWidth), "hello", "─".repeat(innerWidth)];
+		const framed = frameEditorLines(inner, innerWidth + 4, paint);
+
+		const top = stripTerminalSequences(framed[0] ?? "");
+		const content = stripTerminalSequences(framed[1] ?? "");
+		const bottom = stripTerminalSequences(framed[2] ?? "");
+		expect(top).toBe(`╭${"─".repeat(innerWidth + 2)}╮`);
+		expect(content.startsWith("│ ")).toBe(true);
+		expect(content.endsWith(" │")).toBe(true);
+		expect(content).toContain("hello");
+		expect(visibleWidth(content)).toBe(innerWidth + 4);
+		expect(bottom).toBe(`╰${"─".repeat(innerWidth + 2)}╯`);
+		expect(framed).toHaveLength(3);
+		for (const line of framed) expect(visibleWidth(line)).toBe(innerWidth + 4);
+		expect(framed[0]).toContain("\u001b[38;2;102;102;102m╭");
+		expect(framed[1]).toContain("\u001b[38;2;102;102;102m│\u001b[39m");
+	});
+
+	it("keeps autocomplete inside the frame and preserves scroll indicators", () => {
+		const innerWidth = 16;
+		const inner = [`─── ↑ 2 more ${"─".repeat(3)}`, "draft", `─── ↓ 4 more ${"─".repeat(3)}`, "/atelier"];
+		const framed = frameEditorLines(inner, innerWidth + 4, (text) => text);
+
+		expect(framed[0]).toContain("╭─── ↑ 2 more");
+		expect(framed[0]?.endsWith("╮")).toBe(true);
+		expect(framed[1]?.startsWith("│ ")).toBe(true);
+		expect(framed[1]).toContain("draft");
+		expect(framed[2]).toContain("/atelier");
+		expect(framed[3]).toContain("╰─── ↓ 4 more");
+		expect(framed[3]?.endsWith("╯")).toBe(true);
+		expect(framed).toHaveLength(4);
+		for (const line of framed) expect(visibleWidth(line)).toBe(innerWidth + 4);
+	});
+
+	it("does not frame below the minimum width", () => {
+		const inner = ["────────", "text", "────────"];
+		const framed = frameEditorLines(inner, EDITOR_FRAME_MIN_WIDTH - 1, paint);
+		expect(framed.some((line) => line.includes("╭") || line.includes("╰"))).toBe(false);
+		expect(framed[1]).toBe("text");
+		for (const line of framed) expect(visibleWidth(line)).toBeLessThanOrEqual(EDITOR_FRAME_MIN_WIDTH - 1);
+	});
+});
+
+describe("AtelierEditor", () => {
+	it("renders an empty composer inside a rounded frame", () => {
+		const editor = new AtelierEditor(
+			{ requestRender: vi.fn(), terminal: { rows: 24, columns: 48 } } as never,
+			{ borderColor: (text: string) => text, selectList: {} } as never,
+			{ matches: () => false } as never,
+		);
+
+		const lines = editor.render(40);
+		expect(lines[0]).toMatch(/^╭─+╮$/);
+		expect(lines.at(-1)).toMatch(/^╰─+╯$/);
+		expect(lines.some((line) => line.startsWith("│ ") && line.endsWith(" │"))).toBe(true);
+		for (const line of lines) expect(visibleWidth(line)).toBe(40);
+	});
+});

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -7,6 +7,7 @@ import atelierExtension, {
 	SIDEBAR_PANEL_EVENT_CHANNEL,
 	type AtelierExtensionDependencies,
 } from "../extensions/index.js";
+import { AtelierEditor } from "../src/editor.js";
 import {
 	loadConfig as loadAtelierConfig,
 	saveUserConfig as persistConfig,
@@ -50,6 +51,7 @@ function harness(
 	const shortcuts: string[] = [];
 	const shortcutHandlers = new Map<string, (ctx: any) => Promise<void> | void>();
 	const setFooter = vi.fn();
+	const setEditorComponent = vi.fn();
 	let terminalInput: ((data: string) => unknown) | undefined;
 	let terminalInputUnsubscribe = vi.fn();
 	const terminalWrite = vi.fn();
@@ -146,6 +148,7 @@ function harness(
 		},
 		ui: {
 			setFooter,
+			setEditorComponent,
 			notify: vi.fn(),
 			theme: {},
 			select: vi.fn(),
@@ -178,6 +181,7 @@ function harness(
 		shortcuts,
 		shortcutHandlers,
 		setFooter,
+		setEditorComponent,
 		ctx,
 		pi,
 		overlays,
@@ -354,6 +358,16 @@ describe("extension registration", () => {
 		expect(h.commands.has("atelier")).toBe(true);
 		await start(h);
 		expect(h.setFooter).toHaveBeenCalledTimes(1);
+		expect(h.setEditorComponent).toHaveBeenCalledTimes(1);
+		const editorFactory = h.setEditorComponent.mock.calls[0]?.[0];
+		expect(editorFactory).toEqual(expect.any(Function));
+		const editor = editorFactory(
+			{ requestRender: vi.fn(), terminal: { rows: 24, columns: 80 } },
+			{ borderColor: (text: string) => text, selectList: {} },
+			{ matches: () => false },
+		);
+		expect(editor).toBeInstanceOf(AtelierEditor);
+		expect(editor.render(32)[0]).toMatch(/^╭─+╮$/);
 		expect(h.shortcuts).toContain("alt+a");
 		expect(h.shortcuts).toContain("ctrl+shift+r");
 	});
@@ -384,6 +398,7 @@ describe("extension registration", () => {
 		const h = harness("print");
 		await start(h);
 		expect(h.setFooter).not.toHaveBeenCalled();
+		expect(h.setEditorComponent).not.toHaveBeenCalled();
 	});
 
 	it("starts with the Sidebar hidden when the global preference is off", async () => {
@@ -415,6 +430,7 @@ describe("extension registration", () => {
 		expect(h.notificationProcess.kill).toHaveBeenCalledOnce();
 		expect(h.overlays[0]?.done).toHaveBeenCalledOnce();
 		expect(h.setFooter).toHaveBeenLastCalledWith(undefined);
+		expect(h.setEditorComponent).toHaveBeenLastCalledWith(undefined);
 		h.pi.events.emit("rpiv:ask-user:blocked", { active: false });
 		h.pi.events.emit("rpiv:ask-user:blocked", { active: true });
 		expect(h.spawnNotificationProcess).toHaveBeenCalledOnce();
@@ -982,19 +998,26 @@ describe("extension registration", () => {
 		expect(h.terminalWrite).toHaveBeenLastCalledWith("\u001b[?1006l\u001b[?1002l");
 		expect(h.overlays[0]?.tui.render(120)).toEqual(["main:120"]);
 		expect(h.setFooter).toHaveBeenLastCalledWith(undefined);
+		expect(h.setEditorComponent).toHaveBeenLastCalledWith(undefined);
 	});
 
 	it("disable clears the session's own footer, not the invoking context's", async () => {
 		const h = harness();
 		await start(h);
 		h.setFooter.mockClear();
+		h.setEditorComponent.mockClear();
 		// Pi hands commands a context object that shares the session manager but not the UI.
-		const distinctUi = { ...h.ctx, ui: { ...h.ctx.ui, setFooter: vi.fn(), notify: vi.fn() } };
+		const distinctUi = {
+			...h.ctx,
+			ui: { ...h.ctx.ui, setFooter: vi.fn(), setEditorComponent: vi.fn(), notify: vi.fn() },
+		};
 
 		await command(h, "disable", distinctUi);
 
 		expect(h.setFooter).toHaveBeenCalledWith(undefined);
+		expect(h.setEditorComponent).toHaveBeenCalledWith(undefined);
 		expect(distinctUi.ui.setFooter).not.toHaveBeenCalled();
+		expect(distinctUi.ui.setEditorComponent).not.toHaveBeenCalled();
 	});
 
 	it("closes an enabled sidebar and resize input during shutdown", async () => {
@@ -1009,6 +1032,7 @@ describe("extension registration", () => {
 
 		expect(h.overlays[0]?.done).toHaveBeenCalledOnce();
 		expect(h.setFooter).toHaveBeenLastCalledWith(undefined);
+		expect(h.setEditorComponent).toHaveBeenLastCalledWith(undefined);
 		expect(h.terminalWrite).toHaveBeenLastCalledWith("\u001b[?1006l\u001b[?1002l");
 		expect(h.terminalInputUnsubscribe).toHaveBeenCalledOnce();
 		expect(h.terminalInput).toBeUndefined();

--- a/tests/footer.test.ts
+++ b/tests/footer.test.ts
@@ -186,6 +186,12 @@ describe("footer", () => {
 		expect(line.indexOf("in 324k")).toBeGreaterThan(line.indexOf("main*"));
 	});
 
+	it("dims identity separators without a zone rule", () => {
+		const line = renderFooterLine(state, DEFAULT_CONFIG, namedTheme("dark"), 400);
+		expect(line).toContain(`${darkRgb.dim} · \u001b[39m`);
+		expect(stripAnsi(line)).not.toContain("│");
+	});
+
 	it("removes optional information in the approved order", () => {
 		const gitAndThinkingGone = Math.min(firstWidthWithout("main*"), firstWidthWithout("medium"));
 		const costGone = firstWidthWithout("$5.041");

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -40,6 +40,7 @@ describe("npm package contract", () => {
 		expect(readme).toContain("/atelier sidebar");
 		expect(readme).toContain("Ctrl+Shift+R");
 		expect(readme).toContain("hides when the terminal is too narrow");
+		expect(readme).toContain("rounded frame");
 	});
 
 	it("exports the deliberate structured contribution contract from the package entrypoint", () => {


### PR DESCRIPTION
## Summary

Polish the composer and Status Rail: a rounded composer frame with inner padding, and quieter identity separators on the Status Rail.

## Issue and scope

- [x] I linked the issue for this change, when an issue was required.
- [x] This PR contains one coherent change or user-facing behavior.
- [x] Unrelated changes and non-goals are called out below or split into another PR.

**Issue:** #38

**Scope / non-goals:** Composer chrome via `setEditorComponent`, dim Status Rail ` · ` separators, README/CHANGELOG, and tests. Does not change Status Rail segments, drop ranks, metric copy, thinking-level/bash-mode border coloring, or sidebar frames.

## Validation

- [x] I ran `npm run check` (mandatory for every PR, including docs-only; it is the complete repository gate).
- [x] I ran `git diff --check origin/main...HEAD` against the updated `main`.
- [x] I added or updated regression tests through the relevant public/runtime seam for behavior changes.
- [x] For configuration, event, or sidebar behavior, relevant edge cases are covered or explained below.
- [x] For TUI changes (sidebar, footer, menu, or overlay), I manually validated with `npx --no-install pi -e .` (or an equivalent supported global `pi -e .`).
- [x] For TUI changes, I provided a screenshot/recording URL or attached artifact, terminal dimensions/context, and observed result below.

**Commands and results:** `npm run check` passed (typecheck, lint, format, 463 tests, pack). `git diff --check origin/main...HEAD` clean.

**Manual validation:** `npx --no-install pi --no-extensions -e .` on macOS, Pi 0.84, idle TUI. Composer shows a rounded frame; Status Rail keeps two-zone layout without a mid-gap rule.

**Screenshots / recordings:** Reviewer screenshot of the idle composer and Status Rail after the frame change; the mid-gap zone rule was removed from that design.

## Documentation and compatibility

- [x] I updated `README.md` and `CHANGELOG.md` under `Unreleased` when this user-visible change requires it.
- [x] Configuration or documentation impact is described below.
- [x] Known limitations and compatibility considerations are described below.

**Config/docs impact:** README notes the rounded composer frame and that Pi still allows one custom editor at a time. CHANGELOG Unreleased records the composer frame and dim identity separators.

**Known limitations:** Atelier takes over Pi's custom editor while enabled, same as the custom footer. Disable, non-TUI, and session teardown restore the default editor.

## Release safety

- [x] This PR does not publish packages, change release versions, create tags/releases, or edit npm publishing credentials.
