### PR TITLE
Keep Sidebar calm during active Turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Keep the Sidebar calm during an active Turn: Activity shows current work instead of a tool log, extra live tools fold into one row, and TODOS lists only the in-progress task.
+
 ## 0.9.0 — 2026-08-28
 
 - Frame the composer with a rounded box and inner padding while preserving Pi's thinking-level and bash-mode border colors, and dim Status Rail identity separators to emphasize activity.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A responsive status rail and activity sidebar for [Pi](https://pi.dev).
 ## Features
 
 - Responsive one-line status rail
-- Live agent, tool, context, workspace, usage, and TODO information
+- Live agent, tool, context, workspace, usage, and TODO information, kept compact while a Turn is running
 - Model, thinking-level, and tool controls
 - Configurable display presets, segments, and sidebar panels
 - Session details, rename, and compaction actions

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -567,8 +567,12 @@ function todosRows(snapshot: SidebarSnapshot, palette: AtelierPalette): string[]
 	const done = todoList.filter((t) => t.status === "completed").length;
 	const total = todoList.length;
 	const rows = [palette.paint("muted", `${done}/${total}`)];
+	const visible =
+		snapshot.runActivity.phase === "running"
+			? todoList.filter((todo) => todo.status === "in_progress")
+			: todoList;
 
-	for (const todo of todoList) {
+	for (const todo of visible) {
 		let check: string;
 		if (todo.status === "completed") check = palette.paint("ready", "✓");
 		else if (todo.status === "in_progress") check = palette.paint("warning", "◐");
@@ -713,10 +717,14 @@ function toolActivityRow(
 	contentWidth: number,
 	palette: AtelierPalette,
 	now: number,
+	extraLive = 0,
 ): string {
 	const safeName = sanitize(tool.name) || "tool";
 	const safeSummary = sanitize(tool.summary);
-	const status = toolStatusLabel(tool, now);
+	const status =
+		extraLive > 0 && tool.status === "running"
+			? `${durationForTool(tool, now)} · +${finiteCount(extraLive)}`
+			: toolStatusLabel(tool, now);
 	const statusWidth = visibleWidth(status);
 	const nameWidth = Math.min(Math.max(visibleWidth(safeName), 4), 10, Math.max(0, contentWidth));
 	const summaryWidth = Math.max(0, contentWidth - nameWidth - statusWidth - 2);
@@ -752,16 +760,25 @@ function activityRows(
 	palette: AtelierPalette,
 	now: number,
 ): ActivityGroups {
+	const liveTurn = activity.phase === "running";
 	const activeIds = new Set(activity.activeTools.map((tool) => tool.id));
-	const active = activity.activeTools
+	const sortedActive = activity.activeTools
 		.map((tool, index) => ({ index, tool }))
 		.sort((left, right) => left.tool.startedAt - right.tool.startedAt || left.index - right.index)
-		.map(({ tool }) => ({ id: tool.id, row: toolActivityRow(tool, contentWidth, palette, now) }));
-	const recent = activity.recentTools
-		.filter((tool) => !activeIds.has(tool.id))
-		.slice(0, 3)
-		.map((tool) => ({ id: tool.id, row: toolActivityRow(tool, contentWidth, palette, now) }));
-	const aggregateText = aggregateActivityText(activity);
+		.map(({ tool }) => tool);
+	const visibleActive = liveTurn ? sortedActive.slice(-1) : sortedActive;
+	const extraLive = liveTurn ? Math.max(0, sortedActive.length - visibleActive.length) : 0;
+	const active = visibleActive.map((tool) => ({
+		id: tool.id,
+		row: toolActivityRow(tool, contentWidth, palette, now, extraLive),
+	}));
+	const recent = liveTurn
+		? []
+		: activity.recentTools
+				.filter((tool) => !activeIds.has(tool.id))
+				.slice(0, 3)
+				.map((tool) => ({ id: tool.id, row: toolActivityRow(tool, contentWidth, palette, now) }));
+	const aggregateText = liveTurn ? "" : aggregateActivityText(activity);
 	return {
 		core: [runSummaryRow(activity, palette, now), responsePerformanceRow(activity, palette)],
 		active,

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -1041,7 +1041,10 @@ describe("extension registration", () => {
 	it("clears session-owned sidebar state during shutdown", async () => {
 		const h = harness();
 		h.ctx.sessionManager.getBranch.mockReturnValue([
-			todoBranchEntry({ todos: [{ id: 1, text: "Shutdown stale TODO", done: false }], nextId: 2 }),
+			todoBranchEntry({
+				tasks: [{ id: 1, subject: "Shutdown stale TODO", status: "in_progress" }],
+				nextId: 2,
+			}),
 		]);
 		await start(h);
 		await h.handlers.get("agent_start")?.({ type: "agent_start" }, h.ctx);
@@ -2040,10 +2043,10 @@ describe("extension registration", () => {
 			);
 
 			const withResult = h.overlays[0]?.component.render(44).join("\n") ?? "";
-			expect(withResult).toContain("read");
-			expect(withResult).toContain("src/run-activity.ts");
-			expect(withResult).toContain("done 1s");
-			expect(withResult).toContain("tools 1 done · 0 failed");
+			expect(withResult).toContain("Run · running");
+			expect(withResult).not.toContain("src/run-activity.ts");
+			expect(withResult).not.toContain("done 1s");
+			expect(withResult).not.toContain("tools 1 done · 0 failed");
 
 			const rendersBeforeTick = h.overlays[0]?.requestRender.mock.calls.length ?? 0;
 			vi.advanceTimersByTime(1_000);
@@ -2056,12 +2059,60 @@ describe("extension registration", () => {
 			expect(settledText).toContain("Last run · 3s");
 			expect(settledText).not.toContain("settled 3s");
 			expect(settledText).toContain("Ready");
+			expect(settledText).toContain("read");
+			expect(settledText).toContain("src/run-activity.ts");
+			expect(settledText).toContain("done 1s");
 
 			vi.advanceTimersByTime(3_000);
 			expect(h.overlays[0]?.requestRender.mock.calls.length).toBe(settledRenderCount);
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	it("keeps a live Turn overlay to current work without history", async () => {
+		const h = harness();
+		h.ctx.sessionManager.getBranch.mockReturnValue([
+			todoBranchEntry({
+				tasks: [
+					{ id: 1, subject: "Done live TODO", status: "completed" },
+					{ id: 2, subject: "Current live TODO", status: "in_progress" },
+					{ id: 3, subject: "Queued live TODO", status: "pending" },
+				],
+				nextId: 4,
+			}),
+		]);
+		await start(h);
+		await command(h, "sidebar on");
+		await h.handlers.get("agent_start")?.({ type: "agent_start" }, h.ctx);
+		await h.handlers.get("turn_start")?.({ type: "turn_start", turnIndex: 1, timestamp: 1_000 }, h.ctx);
+		await h.handlers.get("tool_execution_start")?.(
+			{
+				type: "tool_execution_start",
+				toolCallId: "older",
+				toolName: "read",
+				args: { path: "/tmp/project/older.ts" },
+			},
+			h.ctx,
+		);
+		await h.handlers.get("tool_execution_start")?.(
+			{
+				type: "tool_execution_start",
+				toolCallId: "newer",
+				toolName: "write",
+				args: { path: "/tmp/project/newer.ts" },
+			},
+			h.ctx,
+		);
+
+		const live = renderOverlayText(h);
+		expect(live).toContain("Turn 2 · running");
+		expect(live).toContain("newer.ts");
+		expect(live).toContain("+1");
+		expect(live).not.toContain("older.ts");
+		expect(live).toContain("Current live TODO");
+		expect(live).not.toContain("Done live TODO");
+		expect(live).not.toContain("Queued live TODO");
 	});
 
 	it("clears run activity across session reload and shutdown", async () => {

--- a/tests/sidebar.test.ts
+++ b/tests/sidebar.test.ts
@@ -1306,19 +1306,15 @@ describe("sidebar snapshot and layout", () => {
 		expect(rows).toEqual(expect.not.arrayContaining([expect.stringMatching(/^[A-Z &]+ ─/)]));
 	});
 
-	it("renders deterministic live run activity", () => {
+	it("keeps a live Turn's ACTIVITY to current work without tool history", () => {
 		const rows = contentRows(
 			renderSidebarLines(withActivity(activeActivity()), DEFAULT_CONFIG, theme, 44, 36, false, 20_000),
 		);
 		expect(rows).toContain("ACTIVITY");
 		expect(rows).toContain("Turn 3 · running 19s");
-		expect(rows).toEqual(
-			expect.arrayContaining([
-				expect.stringMatching(/^read\s+src\/state\.ts\s+18s$/),
-				expect.stringMatching(/^bash\s+npm test\s+done 4s$/),
-			]),
-		);
-		expect(rows).toContain("tools 2 done · 1 failed");
+		expect(rows).toEqual(expect.arrayContaining([expect.stringMatching(/^read\s+src\/state\.ts\s+18s$/)]));
+		expect(rows).not.toEqual(expect.arrayContaining([expect.stringMatching(/^bash\s+npm test\s+done 4s$/)]));
+		expect(rows).not.toContain("tools 2 done · 1 failed");
 	});
 
 	it.each([
@@ -1556,7 +1552,7 @@ describe("sidebar snapshot and layout", () => {
 		expect(idleWithCounts).toContain("tools 0 done · 2 failed");
 	});
 
-	it("keeps active tools before recent tools and preserves parallel start order", () => {
+	it("folds extra live tools into the current work row during a Turn", () => {
 		const rows = contentRows(
 			renderSidebarLines(
 				withActivity({
@@ -1589,21 +1585,17 @@ describe("sidebar snapshot and layout", () => {
 				20_000,
 			),
 		);
-		const first = rows.findIndex((row) => /^read\s+same-a/.test(row));
-		const third = rows.findIndex((row) => /^bash\s+same-b/.test(row));
-		const second = rows.findIndex((row) => /^grep\s+later/.test(row));
-		const recent = rows.findIndex((row) => /^write\s+recent/.test(row));
-		expect([first, third, second, recent].every((index) => index > -1)).toBe(true);
-		expect(first).toBeLessThan(third);
-		expect(third).toBeLessThan(second);
-		expect(second).toBeLessThan(recent);
+		expect(rows).toEqual(expect.arrayContaining([expect.stringMatching(/^grep\s+later\s+7s · \+2$/)]));
+		expect(rows).not.toEqual(expect.arrayContaining([expect.stringMatching(/^read\s+same-a/)]));
+		expect(rows).not.toEqual(expect.arrayContaining([expect.stringMatching(/^bash\s+same-b/)]));
+		expect(rows.findIndex((row) => /^write\s+recent/.test(row))).toBe(-1);
 	});
 
 	it("caps recent tools, deduplicates active IDs, and bounds long summaries", () => {
 		const rows = contentRows(
 			renderSidebarLines(
 				withActivity({
-					phase: "running",
+					phase: "settled",
 					startedAt: 0,
 					activeTools: [{ id: "dupe", name: "read", summary: "active", status: "running", startedAt: 1_000 }],
 					recentTools: [
@@ -1670,7 +1662,7 @@ describe("sidebar snapshot and layout", () => {
 	});
 
 	it("uses success, error, and working palette roles for activity status", () => {
-		const fg = vi.fn((_color: string, text: string) => text);
+		const liveFg = vi.fn((_color: string, text: string) => text);
 		renderSidebarLines(
 			withActivity({
 				phase: "running",
@@ -1678,6 +1670,26 @@ describe("sidebar snapshot and layout", () => {
 				activeTools: [
 					{ id: "active", name: "read", summary: "src/a.ts", status: "running", startedAt: 10_000 },
 				],
+				recentTools: [],
+				completedCount: 0,
+				failedCount: 0,
+			}),
+			DEFAULT_CONFIG,
+			{ fg: liveFg, bold: theme.bold, italic: theme.italic },
+			44,
+			36,
+			true,
+			20_000,
+		);
+		expect(liveFg).toHaveBeenCalledWith("mdHeading", "10s");
+
+		const settledFg = vi.fn((_color: string, text: string) => text);
+		renderSidebarLines(
+			withActivity({
+				phase: "settled",
+				startedAt: 10_000,
+				durationMs: 10_000,
+				activeTools: [],
 				recentTools: [
 					{ id: "ok", name: "bash", summary: "ok", status: "done", startedAt: 9_000, durationMs: 1_000 },
 					{ id: "bad", name: "edit", summary: "bad", status: "failed", startedAt: 8_000, durationMs: 1_000 },
@@ -1686,15 +1698,14 @@ describe("sidebar snapshot and layout", () => {
 				failedCount: 1,
 			}),
 			DEFAULT_CONFIG,
-			{ fg, bold: theme.bold, italic: theme.italic },
+			{ fg: settledFg, bold: theme.bold, italic: theme.italic },
 			44,
 			36,
 			true,
 			20_000,
 		);
-		expect(fg).toHaveBeenCalledWith("mdHeading", "10s");
-		expect(fg).toHaveBeenCalledWith("thinkingLow", "done 1s");
-		expect(fg).toHaveBeenCalledWith("error", "failed 1s");
+		expect(settledFg).toHaveBeenCalledWith("thinkingLow", "done 1s");
+		expect(settledFg).toHaveBeenCalledWith("error", "failed 1s");
 	});
 
 	it("drops workspace details, tools, then usage as height contracts", () => {
@@ -1736,16 +1747,16 @@ describe("sidebar snapshot and layout", () => {
 			failedCount: 1,
 		});
 
-		const fullRows = contentRows(renderSidebarLines(ranked, DEFAULT_CONFIG, theme, 44, 43, false, 20_000));
+		const fullRows = contentRows(renderSidebarLines(ranked, DEFAULT_CONFIG, theme, 44, 40, false, 20_000));
 		expect(fullRows).toContain("TOOLS");
 		expect(fullRows).toContain("USAGE");
 		expect(fullRows).toContain("WORKSPACE");
-		expect(fullRows.findIndex((row) => /^read\s+active-a/.test(row))).toBeLessThan(
+		expect(fullRows.findIndex((row) => /^bash\s+active-b/.test(row))).toBeLessThan(
 			fullRows.indexOf("CONTEXT"),
 		);
 
 		const withoutSession = contentRows(
-			renderSidebarLines(ranked, DEFAULT_CONFIG, theme, 44, 36, false, 20_000),
+			renderSidebarLines(ranked, DEFAULT_CONFIG, theme, 44, 32, false, 20_000),
 		);
 		expect(withoutSession).toContain("TOOLS");
 		expect(withoutSession).toContain("USAGE");
@@ -1754,13 +1765,13 @@ describe("sidebar snapshot and layout", () => {
 		expect(withoutSession).not.toContain("38 entries · persisted");
 
 		const withoutTools = contentRows(
-			renderSidebarLines(ranked, DEFAULT_CONFIG, theme, 44, 32, false, 20_000),
+			renderSidebarLines(ranked, DEFAULT_CONFIG, theme, 44, 28, false, 20_000),
 		);
 		expect(withoutTools).not.toContain("TOOLS");
 		expect(withoutTools).toContain("USAGE");
 		expect(withoutTools).toContain("WORKSPACE");
 
-		const coreOnly = contentRows(renderSidebarLines(ranked, DEFAULT_CONFIG, theme, 44, 26, false, 20_000));
+		const coreOnly = contentRows(renderSidebarLines(ranked, DEFAULT_CONFIG, theme, 44, 22, false, 20_000));
 		expect(coreOnly).not.toContain("TOOLS");
 		expect(coreOnly).not.toContain("USAGE");
 		expect(coreOnly).toContain("WORKSPACE");
@@ -2439,6 +2450,31 @@ describe("todos panel", () => {
 	it("omits todos panel when list is empty", () => {
 		const rows = contentRows(renderSidebarLines(snapshot(), DEFAULT_CONFIG, theme, 44, 36, false));
 		expect(rows).not.toContain("TODOS");
+	});
+
+	it("keeps only the in-progress todo during a live Turn", () => {
+		const snapWithTodos = buildSidebarSnapshot({
+			state,
+			cwd: "/Users/example/projects/pi-atelier",
+			sessionName: "Sidebar implementation",
+			sessionFile: "/tmp/session.jsonl",
+			branchEntryCount: 38,
+			activeToolCount: 8,
+			availableToolCount: 12,
+			extensionStatuses: ["tests passing"],
+			runActivity: activeActivity(),
+			todos: [
+				{ id: 1, text: "Review diff", status: "completed" },
+				{ id: 2, text: "Write tests", status: "in_progress" },
+				{ id: 3, text: "Commit changes", status: "pending" },
+			],
+		});
+		const rows = contentRows(renderSidebarLines(snapWithTodos, DEFAULT_CONFIG, theme, 44, 48, false, 20_000));
+		expect(rows).toContain("TODOS");
+		expect(rows).toContain("1/3");
+		expect(rows).toContain("◐ #2 Write tests");
+		expect(rows).not.toContain("✓ #1 Review diff");
+		expect(rows).not.toContain("○ #3 Commit changes");
 	});
 
 	it("renders todos with all 3 status states", () => {


### PR DESCRIPTION
## Summary

Keep the Sidebar calm during an active Turn: Activity shows current work instead of a tool log, extra live tools fold into one row, and TODOS lists only the in-progress task.

## Issue and scope

- [x] I linked the issue for this change, when an issue was required.
- [x] This PR contains one coherent change or user-facing behavior.
- [x] Unrelated changes and non-goals are called out below or split into another PR.

**Issue:** Closes #40

**Scope / non-goals:** Live-Turn Activity and TODOS density via `renderSidebarLines`, README/CHANGELOG, and tests. Does not redesign idle frames, the contribution protocol, Settings layout editor, Status Rail/composer chrome, or add new live metrics. AGENT jewel pulse stays.

## Validation

- [x] I ran `npm run check` (mandatory for every PR, including docs-only; it is the complete repository gate).
- [x] I ran `git diff --check origin/main...HEAD` against the updated `main`.
- [x] I added or updated regression tests through the relevant public/runtime seam for behavior changes.
- [x] For configuration, event, or sidebar behavior, relevant edge cases are covered or explained below.
- [x] For TUI changes (sidebar, footer, menu, or overlay), I manually validated with `npx --no-install pi -e .` (or an equivalent supported global `pi -e .`).
- [ ] For TUI changes, I provided a screenshot/recording URL or attached artifact, terminal dimensions/context, and observed result below.

**Commands and results:** `npm run check` passed (typecheck, lint, format, 465 tests, pack). `git diff --check origin/main...HEAD` clean.

**Manual validation:** Waived by maintainer — TUI screenshot not required for this change.

**Screenshots / recordings:** Not applicable — maintainer waived the screenshot requirement.

## Documentation and compatibility

- [x] I updated `README.md` and `CHANGELOG.md` under `Unreleased` when this user-visible change requires it.
- [x] Configuration or documentation impact is described below.
- [x] Known limitations and compatibility considerations are described below.

**Config/docs impact:** README notes that live agent/tool/TODO information stays compact while a Turn is running. CHANGELOG Unreleased records the live-Turn density change.

**Known limitations:** Concurrent live tools besides the current one are folded into `+N`. Completed and pending TODOs stay hidden until the Turn settles.

## Release safety

- [x] This PR does not publish packages, change release versions, create tags/releases, or edit npm publishing credentials.
