### PR TITLE
fix(footer): strip full ANSI CSI sequences in sanitize, matching sidebar

### DIFF
--- a/src/footer.ts
+++ b/src/footer.ts
@@ -59,6 +59,7 @@ const DROP = {
 
 const sanitize = (text: string): string =>
 	text
+		.replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "")
 		.replace(/[\u0000-\u001f\u007f]/g, " ")
 		.replace(/\s+/g, " ")
 		.trim();


### PR DESCRIPTION
# fix: strip full ANSI sequences in footer sanitize, matching sidebar

## Summary

A one-line fix to align `footer.ts`'s `sanitize()` function with the identical function already present in `sidebar.ts`. The footer version was silently dropping extension statuses set by other extensions by miscounting their visual width.

---

## The bug

`footer.ts` and `sidebar.ts` both define a local `sanitize()` function to clean up strings before rendering. The two implementations are supposed to be equivalent, but they diverged at some point. `sidebar.ts` correctly strips complete ANSI CSI escape sequences using a proper regex:

```ts
// sidebar.ts — correct
const sanitize = (text: string): string =>
    text
        .replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "")  // ← strips full sequence
        .replace(/[\u0000-\u001f\u007f]/g, " ")
        .replace(/\s+/g, " ")
        .trim();
```

`footer.ts` was missing that first line entirely:

```ts
// footer.ts — before this fix
const sanitize = (text: string): string =>
    text
        .replace(/[\u0000-\u001f\u007f]/g, " ")  // only strips the ESC byte
        .replace(/\s+/g, " ")
        .trim();
```

An ANSI escape sequence like `\x1b[33msome text\x1b[0m` is composed of two parts: the ESC control character (`\x1b`, 0x1B) and the rest of the sequence (`[33m`, `[0m`). The footer's sanitize stripped only the ESC byte and left the remainder — `[33m`, `[0m` — as visible text.

---

## Why this matters: the status segment gets silently dropped

When another Pi extension sets a colored status via `ctx.ui.setStatus()`, the text passed in is typically ANSI-colored (produced by `theme.fg()`). The footer reads those statuses through `footerData.getExtensionStatuses()` and passes each one through `sanitize()` before measuring and rendering.

With the broken sanitize, a colored string like `\x1b[33m23%\x1b[0m` became ` [33m23% [0m` after sanitize — four extra visible characters that don't exist on screen. `visibleWidth()` from `@earendil-works/pi-tui` handles real ANSI sequences correctly, but it never got the chance to: the ANSI had already been partially mangled into plain ASCII before reaching it.

Those phantom characters inflated the measured width of the statuses segment. The footer's `compose()` function drops segments in `dropRank` order when the footer is too wide, and the statuses segment has `dropRank: 0` — the lowest priority, first to go. So whenever a colored status was present, `compose()` measured the footer as too wide and removed the entire statuses segment, even on wide terminals where it would otherwise fit comfortably.

The result: any extension that sets a colored status via `ctx.ui.setStatus()` would have that status silently removed from the footer rail. The sidebar was unaffected because it uses the correct sanitize.

---

## The fix

Add the missing ANSI CSI regex as the first step in `footer.ts`'s `sanitize()`, making it identical to `sidebar.ts`:

```ts
const sanitize = (text: string): string =>
    text
        .replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "")  // ← added
        .replace(/[\u0000-\u001f\u007f]/g, " ")
        .replace(/\s+/g, " ")
        .trim();
```

After this change, `sanitize()` correctly removes the full escape sequence before the string reaches `visibleWidth()`, so width measurements are accurate and the statuses segment is no longer incorrectly dropped.

---

## Impact

This affects any Pi extension that calls `ctx.ui.setStatus()` with a colored string. The statuses segment will now appear in the footer rail as intended, as long as the terminal is wide enough for it (it remains the lowest-priority segment and will still be dropped before others on narrow terminals — that behavior is correct and unchanged).